### PR TITLE
log_level instead logmsg in SolveIpForm

### DIFF
--- a/src/Algorithm/colgen.jl
+++ b/src/Algorithm/colgen.jl
@@ -173,7 +173,7 @@ function solve_sp_to_gencol!(
 
     # Solve sub-problem and insert generated columns in master
     # @logmsg LogLevel(-3) "optimizing pricing prob"
-    ipform = SolveIpForm(deactivate_artificial_vars = false, enforce_integrality = false, log_level = 2)
+    ipform = SolveIpForm(deactivate_artificial_vars = false, enforce_integrality = false, log_level = 1)
     TO.@timeit Coluna._to "Pricing subproblem" begin
         output = run!(ipform, spform, OptimizationInput(OptimizationState(spform)))
     end

--- a/src/Algorithm/conquer.jl
+++ b/src/Algorithm/conquer.jl
@@ -137,6 +137,7 @@ function run!(algo::ColGenConquer, reform::Reformulation, input::ConquerInput)
     if (!to_be_pruned(node))
         node.conquerrecord = record!(reform)
         if algo.run_mastipheur 
+            @logmsg LogLevel(0) "Run IP restricted master heuristic."
             heur_output = run!(
                 algo.mastipheur, getmaster(reform), OptimizationInput(nodestate)
             )

--- a/src/Algorithm/solveipform.jl
+++ b/src/Algorithm/solveipform.jl
@@ -8,18 +8,8 @@ Base.@kwdef struct SolveIpForm <: AbstractOptimizationAlgorithm
     time_limit::Int = 600
     deactivate_artificial_vars = true
     enforce_integrality = true
-    log_level = 1
+    log_level = 0
 end
-
-
-# TO DO : create an Algorithm Logger
-# function Logging.shouldlog(logger::ConsoleLogger, level, _module, group, id)
-#     println("*******")
-#     @show level _module group id
-#     println("log = ", get(logger.message_limits, id, 1))
-#     println("******")
-#     return get(logger.message_limits, id, 1) > 0
-# end
 
 function run!(algo::SolveIpForm, form::Formulation, input::OptimizationInput)::OptimizationOutput
 
@@ -43,18 +33,18 @@ function run!(algo::SolveIpForm, form::Formulation, input::OptimizationInput)::O
     bestprimalsol = getbestprimalsol(optimizer_result)
     if bestprimalsol !== nothing
         add_ip_primal_sol!(optstate, bestprimalsol) 
-
-        @logmsg LogLevel(-1) string(
-            "Found primal solution of ", 
-            @sprintf "%.4f" getvalue(get_ip_primal_bound(optstate))
-        )
+        if algo.log_level == 0
+            @printf "Found primal solution of %.4f \n" getvalue(get_ip_primal_bound(optstate))
+        end
         @logmsg LogLevel(-3) get_best_ip_primal_sol(optstate)
     else
-        @logmsg LogLevel(-1) string(
-            "No primal solution found. Termination status is ", 
-            getterminationstatus(optstate), ". Feasibility status is ",
-            getfeasibilitystatus(optstate), "."
-        )
+        if algo.log_level == 0
+            println(
+                "No primal solution found. Termination status is ", 
+                getterminationstatus(optstate), ". Feasibility status is ",
+                getfeasibilitystatus(optstate), "."
+            )
+        end
     end
     return OptimizationOutput(optstate)
 end

--- a/src/Algorithm/solvelpform.jl
+++ b/src/Algorithm/solvelpform.jl
@@ -7,7 +7,7 @@ Base.@kwdef struct SolveLpForm <: AbstractOptimizationAlgorithm
     get_dual_solution = false
     relax_integrality = false
     set_dual_bound = false
-    log_level = 1
+    log_level = 0
 end
 
 # struct MasterLpRecord <: AbstractAlgorithmResult


### PR DESCRIPTION
@rrsadykov  I think you are right, it's better to use a log_level attribute in algorithms instead of `@logmsg`. However, we should keep the same rules that `@logmsg` :  `1`silent mode, `0` default value, the lower the value (-1, -2, -3...), the more you print.

