### PR TITLE
Representatives of master sol should have master duty

### DIFF
--- a/src/MathProg/projection.jl
+++ b/src/MathProg/projection.jl
@@ -14,7 +14,8 @@ function proj_cols_on_rep(sol::PrimalSolution, master::Formulation{DwMaster})
             col = getprimalsolmatrix(spform)[:, varid]
             for (repid, repval) in col
                 if getduty(repid) <= DwSpPricingVar || getduty(repid) <= DwSpSetupVar
-                    push!(projected_sol_vars, repid)
+                    mastrepid = getid(getvar(master, repid))
+                    push!(projected_sol_vars, mastrepid)
                     push!(projected_sol_vals, repval * val)
                 end
             end


### PR DESCRIPTION
For #323 

In the master solution, subproblem representative variables had subproblem duties instead of master duties.
