### PR TITLE
silent mode for subsolvers

### DIFF
--- a/src/Algorithm/solveipform.jl
+++ b/src/Algorithm/solveipform.jl
@@ -8,6 +8,7 @@ Base.@kwdef struct SolveIpForm <: AbstractOptimizationAlgorithm
     time_limit::Int = 600
     deactivate_artificial_vars = true
     enforce_integrality = true
+    silent = true
     log_level = 0
 end
 
@@ -92,6 +93,7 @@ check_if_optimizer_supports_ip(optimizer::UserOptimizer) = true
 
 function optimize_ip_form!(algo::SolveIpForm, optimizer::MoiOptimizer, form::Formulation)
     MOI.set(optimizer.inner, MOI.TimeLimitSec(), algo.time_limit)
+    MOI.set(optimizer.inner, MOI.Silent(), algo.silent)
     # No way to enforce upper bound through MOI. 
     # Add a constraint c'x <= UB in form ?
 

--- a/src/MathProg/MOIinterface.jl
+++ b/src/MathProg/MOIinterface.jl
@@ -155,16 +155,6 @@ function add_to_optimizer!(form::Formulation, constr::Constraint, var_checker::F
     return
 end
 
-function call_moi_optimize_with_silence(optimizer::MoiOptimizer)
-    backup_stdout = stdout
-    (rd_out, wr_out) = redirect_stdout()
-    MOI.optimize!(getinner(optimizer))
-    close(wr_out)
-    close(rd_out)
-    redirect_stdout(backup_stdout)
-    return
-end
-
 function remove_from_optimizer!(form::Formulation, var::Variable)                       
     inner = getinner(form.optimizer)
     moirecord = getmoirecord(var)

--- a/src/MathProg/optimizerwrappers.jl
+++ b/src/MathProg/optimizerwrappers.jl
@@ -201,7 +201,7 @@ function optimize!(form::Formulation, optimizer::MoiOptimizer)
         @warn "No variable in the formulation. Coluna does not call the solver."
         return retrieve_result(form, optimizer)
     end
-    call_moi_optimize_with_silence(form.optimizer)
+    MOI.optimize!(getinner(form.optimizer))
     status = MOI.get(form.optimizer.inner, MOI.TerminationStatus())
     @logmsg LogLevel(-2) string("Optimization finished with status: ", status)
     return retrieve_result(form, optimizer)

--- a/test/full_instances_tests.jl
+++ b/test/full_instances_tests.jl
@@ -196,7 +196,7 @@ function generalized_assignment_tests()
         try
             JuMP.optimize!(problem)
         catch e
-            @test repr(e) == "ErrorException(\"Function `optimize!` is not defined for object of type Coluna.MathProg.NoOptimizer\")"
+            @test repr(e) == "ErrorException(\"Cannot optimize LP formulation with optimizer of type Coluna.MathProg.NoOptimizer.\")"
         end
     end
     return


### PR DESCRIPTION
use silent attribute to mute subsolvers instead of redirecting the output.

needed in #333 