### PR TITLE
Improve termination statuses

### DIFF
--- a/src/Algorithm/Algorithm.jl
+++ b/src/Algorithm/Algorithm.jl
@@ -16,8 +16,8 @@ const MOI = MathOptInterface
 import Base: push!
 
 # Import to extend methods to OptimizationState
-import ..MathProg: getsolutionstatus, getterminationstatus, setsolutionstatus!,
-    setterminationstatus!, isfeasible, get_ip_primal_bound, get_ip_dual_bound,
+import ..MathProg: getterminationstatus,
+    setterminationstatus!, get_ip_primal_bound, get_ip_dual_bound,
     get_lp_primal_bound, get_lp_dual_bound, update_ip_primal_bound!, update_ip_dual_bound!,
     update_lp_primal_bound!, update_lp_dual_bound!, set_ip_primal_bound!,
     set_ip_dual_bound!, set_lp_primal_bound!, set_lp_dual_bound!, ip_gap, lp_gap
@@ -56,15 +56,13 @@ include("branching/branchingalgo.jl")
 
 include("treesearch.jl")
 
-#include("diving.jl")
-
 # Algorithm should export only methods usefull to define & parametrize algorithms, and
 # data structures from utilities.
 # Other Coluna's submodules should be independent to Algorithm
 
 # Utilities
-export OptimizationState, getterminationstatus, getsolutionstatus, setterminationstatus!,
-    setsolutionstatus!, isfeasible, nb_ip_primal_sols, nb_lp_primal_sols, nb_lp_dual_sols,
+export OptimizationState, getterminationstatus, setterminationstatus!,
+    nb_ip_primal_sols, nb_lp_primal_sols, nb_lp_dual_sols,
     get_ip_primal_sols, get_lp_primal_sols, get_lp_dual_sols, get_best_ip_primal_sol,
     get_best_lp_primal_sol, get_best_lp_dual_sol, update_ip_primal_sol!,
     update_lp_primal_sol!, update_lp_dual_sol!, add_ip_primal_sol!, add_lp_primal_sol!,

--- a/src/Algorithm/Algorithm.jl
+++ b/src/Algorithm/Algorithm.jl
@@ -16,7 +16,7 @@ const MOI = MathOptInterface
 import Base: push!
 
 # Import to extend methods to OptimizationState
-import ..MathProg: getfeasibilitystatus, getterminationstatus, setfeasibilitystatus!,
+import ..MathProg: getsolutionstatus, getterminationstatus, setsolutionstatus!,
     setterminationstatus!, isfeasible, get_ip_primal_bound, get_ip_dual_bound,
     get_lp_primal_bound, get_lp_dual_bound, update_ip_primal_bound!, update_ip_dual_bound!,
     update_lp_primal_bound!, update_lp_dual_bound!, set_ip_primal_bound!,
@@ -63,8 +63,8 @@ include("treesearch.jl")
 # Other Coluna's submodules should be independent to Algorithm
 
 # Utilities
-export OptimizationState, getterminationstatus, getfeasibilitystatus, setterminationstatus!,
-    setfeasibilitystatus!, isfeasible, nb_ip_primal_sols, nb_lp_primal_sols, nb_lp_dual_sols,
+export OptimizationState, getterminationstatus, getsolutionstatus, setterminationstatus!,
+    setsolutionstatus!, isfeasible, nb_ip_primal_sols, nb_lp_primal_sols, nb_lp_dual_sols,
     get_ip_primal_sols, get_lp_primal_sols, get_lp_dual_sols, get_best_ip_primal_sol,
     get_best_lp_primal_sol, get_best_lp_dual_sol, update_ip_primal_sol!,
     update_lp_primal_sol!, update_lp_dual_sol!, add_ip_primal_sol!, add_lp_primal_sol!,

--- a/src/Algorithm/basic/solveipform.jl
+++ b/src/Algorithm/basic/solveipform.jl
@@ -54,7 +54,7 @@ function run!(algo::SolveIpForm, data::ModelData, input::OptimizationInput)::Opt
 
     optimizer_result = optimize_ip_form!(algo, getoptimizer(form), form)
 
-    setfeasibilitystatus!(optstate, getfeasibilitystatus(optimizer_result))
+    setsolutionstatus!(optstate, getsolutionstatus(optimizer_result))
     setterminationstatus!(optstate, getterminationstatus(optimizer_result))
 
     bestprimalsol = getbestprimalsol(optimizer_result)
@@ -68,8 +68,8 @@ function run!(algo::SolveIpForm, data::ModelData, input::OptimizationInput)::Opt
         if algo.log_level == 0
             println(
                 "No primal solution found. Termination status is ",
-                getterminationstatus(optstate), ". Feasibility status is ",
-                getfeasibilitystatus(optstate), "."
+                getterminationstatus(optstate), ". Solution status is ",
+                getsolutionstatus(optstate), "."
             )
         end
     end

--- a/src/Algorithm/basic/solveipform.jl
+++ b/src/Algorithm/basic/solveipform.jl
@@ -48,13 +48,12 @@ function run!(algo::SolveIpForm, data::ModelData, input::OptimizationInput)::Opt
     if !ip_supported
         @warn "Optimizer of formulation with id =", getuid(form),
               " does not support integer variables. Skip SolveIpForm algorithm."
-        setterminationstatus!(optstate, EMPTY_RESULT)
+        setterminationstatus!(optstate, UNKNOWN_TERMINATION_STATUS)
         return OptimizationOutput(optstate)
     end
 
     optimizer_result = optimize_ip_form!(algo, getoptimizer(form), form)
 
-    setsolutionstatus!(optstate, getsolutionstatus(optimizer_result))
     setterminationstatus!(optstate, getterminationstatus(optimizer_result))
 
     bestprimalsol = getbestprimalsol(optimizer_result)
@@ -68,8 +67,7 @@ function run!(algo::SolveIpForm, data::ModelData, input::OptimizationInput)::Opt
         if algo.log_level == 0
             println(
                 "No primal solution found. Termination status is ",
-                getterminationstatus(optstate), ". Solution status is ",
-                getsolutionstatus(optstate), "."
+                getterminationstatus(optstate), ". "
             )
         end
     end

--- a/src/Algorithm/basic/solvelpform.jl
+++ b/src/Algorithm/basic/solvelpform.jl
@@ -56,7 +56,7 @@ function run!(algo::SolveLpForm, data::ModelData, input::OptimizationInput)::Opt
 
     optimizer_result = optimize_lp_form!(algo, getoptimizer(form), form)
 
-    setfeasibilitystatus!(optstate, getfeasibilitystatus(optimizer_result))    
+    setsolutionstatus!(optstate, getsolutionstatus(optimizer_result))    
     setterminationstatus!(optstate, getterminationstatus(optimizer_result))   
 
     lp_primal_sol = getbestprimalsol(optimizer_result)

--- a/src/Algorithm/basic/solvelpform.jl
+++ b/src/Algorithm/basic/solvelpform.jl
@@ -55,8 +55,7 @@ function run!(algo::SolveLpForm, data::ModelData, input::OptimizationInput)::Opt
     end
 
     optimizer_result = optimize_lp_form!(algo, getoptimizer(form), form)
-
-    setsolutionstatus!(optstate, getsolutionstatus(optimizer_result))    
+ 
     setterminationstatus!(optstate, getterminationstatus(optimizer_result))   
 
     lp_primal_sol = getbestprimalsol(optimizer_result)

--- a/src/Algorithm/benders.jl
+++ b/src/Algorithm/benders.jl
@@ -475,12 +475,12 @@ function bend_cutting_plane_main_loop!(
         
         optresult, master_time = solve_relaxed_master!(masterform)
 
-        if getfeasibilitystatus(optresult) == INFEASIBLE
+        if getsolutionstatus(optresult) == INFEASIBLE_SOL
             db = - getvalue(DualBound(masterform))
             pb = - getvalue(PrimalBound(masterform))
             set_lp_dual_bound!(bnd_optstate, DualBound(masterform, db))
             set_lp_primal_bound!(bnd_optstate, PrimalBound(masterform, pb))
-            setfeasibilitystatus!(bnd_optstate, INFEASIBLE)
+            setsolutionstatus!(bnd_optstate, INFEASIBLE_SOL)
             return 
         end
            
@@ -489,7 +489,7 @@ function bend_cutting_plane_main_loop!(
 
         if !isfeasible(optresult) || master_primal_sol === nothing || master_dual_sol === nothing
             error("Benders algorithm:  the relaxed master LP is infeasible or unboundedhas no solution.")
-            setfeasibilitystatus!(bnd_optstate, INFEASIBLE)
+            setsolutionstatus!(bnd_optstate, INFEASIBLE_SOL)
             return 
         end
 
@@ -513,7 +513,7 @@ function bend_cutting_plane_main_loop!(
 
             if nb_new_cuts < 0
                 #@error "infeasible subproblem."
-                setfeasibilitystatus!(bnd_optstate, INFEASIBLE)
+                setsolutionstatus!(bnd_optstate, INFEASIBLE_SOL)
                 return
             end
 
@@ -535,7 +535,7 @@ function bend_cutting_plane_main_loop!(
             
             if nb_bc_iterations >= algo.max_nb_iterations
                 @warn "Maximum number of cut generation iteration is reached."
-                setfeasibilitystatus!(bnd_optstate, INFEASIBLE)
+                setsolutionstatus!(bnd_optstate, INFEASIBLE_SOL)
                 break # loop on separation phases
             end
             

--- a/src/Algorithm/colgen.jl
+++ b/src/Algorithm/colgen.jl
@@ -95,7 +95,7 @@ function run!(algo::ColumnGeneration, data::ReformData, input::OptimizationInput
         end
     end
 
-    @logmsg LogLevel(-1) string("ColumnGeneration terminated with status ", getfeasibilitystatus(optstate))
+    @logmsg LogLevel(-1) string("ColumnGeneration terminated with status ", getsolutionstatus(optstate))
 
     return OptimizationOutput(optstate)
 end
@@ -629,10 +629,10 @@ function cg_main_loop!(
         master_val = get_lp_primal_bound(rm_optstate)
 
         if phase != 1 && !isfeasible(rm_optstate)
-            status = getfeasibilitystatus(rm_optstate)
+            status = getsolutionstatus(rm_optstate)
             @warn string("Solver returned that LP restricted master is infeasible or unbounded ",
             "(feasibility status = " , status, ") during phase != 1.")
-            setfeasibilitystatus!(cg_optstate, status)
+            setsolutionstatus!(cg_optstate, status)
             return true
         end
 
@@ -688,7 +688,8 @@ function cg_main_loop!(
 
             if nb_new_col < 0
                 @error "Infeasible subproblem."
-                setfeasibilitystatus!(cg_optstate, INFEASIBLE)
+                setterminationstatus!(cg_optstate, INFEASIBLE)
+                setsolutionstatus!(cg_optstate, EMPTY_SOL)
                 return true
             end
 
@@ -731,7 +732,7 @@ function cg_main_loop!(
             pb = - getvalue(PrimalBound(reform))
             set_lp_dual_bound!(cg_optstate, DualBound(reform, db))
             set_lp_primal_bound!(cg_optstate, PrimalBound(reform, pb))
-            setfeasibilitystatus!(cg_optstate, INFEASIBLE)
+            setterminationstatus!(cg_optstate, INFEASIBLE)
             @logmsg LogLevel(0) "Phase one determines infeasibility."
             return true
         end

--- a/src/Algorithm/colgen.jl
+++ b/src/Algorithm/colgen.jl
@@ -95,7 +95,7 @@ function run!(algo::ColumnGeneration, data::ReformData, input::OptimizationInput
         end
     end
 
-    @logmsg LogLevel(-1) string("ColumnGeneration terminated with status ", getsolutionstatus(optstate))
+    @logmsg LogLevel(-1) string("ColumnGeneration terminated with status ", getterminationstatus(optstate))
 
     return OptimizationOutput(optstate)
 end
@@ -277,31 +277,33 @@ function solve_sp_to_gencol!(
 
     output = run!(algo.pricing_prob_solve_alg, spdata, OptimizationInput(OptimizationState(spform)))
     sp_optstate = getoptstate(output)
-    spinfo.isfeasible = isfeasible(sp_optstate)
     sp_sol_value = get_ip_primal_bound(sp_optstate)
 
     compute_db_contributions!(spinfo, get_ip_dual_bound(sp_optstate), sp_sol_value)
 
     sense = getobjsense(masterform)
-    if spinfo.isfeasible && nb_ip_primal_sols(sp_optstate) > 0
-        spinfo.bestsol = get_best_ip_primal_sol(sp_optstate)
-        for sol in get_ip_primal_sols(sp_optstate)
-            if improving_red_cost(compute_red_cost(algo, masterform, spinfo, sol, dualsol), algo, sense)
-                insertion_status, col_id = setprimalsol!(spform, sol)
-                if insertion_status
-                    push!(spinfo.recorded_sol_ids, col_id)
-                elseif !insertion_status && !iscuractive(masterform, col_id)
-                    push!(spinfo.sol_ids_to_activate, col_id)
-                else
-                    msg = """
-                    Column already exists as $(getname(masterform, col_id)) and is already active.
-                    """
-                    @warn string(msg)
+    if nb_ip_primal_sols(sp_optstate) > 0
+        bestsol = get_best_ip_primal_sol(sp_optstate)
+        if bestsol.status == FEASIBLE_SOL
+            spinfo.bestsol = bestsol
+            spinfo.isfeasible = true
+            for sol in get_ip_primal_sols(sp_optstate)
+                if improving_red_cost(compute_red_cost(algo, masterform, spinfo, sol, dualsol), algo, sense)
+                    insertion_status, col_id = setprimalsol!(spform, sol)
+                    if insertion_status
+                        push!(spinfo.recorded_sol_ids, col_id)
+                    elseif !insertion_status && !iscuractive(masterform, col_id)
+                        push!(spinfo.sol_ids_to_activate, col_id)
+                    else
+                        msg = """
+                        Column already exists as $(getname(masterform, col_id)) and is already active.
+                        """
+                        @warn string(msg)
+                    end
                 end
             end
         end
     end
-
     return
 end
 
@@ -559,7 +561,7 @@ function move_convexity_constrs_dual_values!(
             push!(values, value)
         end
     end
-    return DualSolution(dualsol.model, constrids, values, newbound)
+    return DualSolution(dualsol.model, constrids, values, newbound, FEASIBLE_SOL)
 end
 
 function get_pure_master_vars(master::Formulation)
@@ -628,11 +630,10 @@ function cg_main_loop!(
         rm_optstate = getoptstate(rm_output)
         master_val = get_lp_primal_bound(rm_optstate)
 
-        if phase != 1 && !isfeasible(rm_optstate)
-            status = getsolutionstatus(rm_optstate)
+        if phase != 1 && getterminationstatus(rm_optstate) == INFEASIBLE
             @warn string("Solver returned that LP restricted master is infeasible or unbounded ",
             "(feasibility status = " , status, ") during phase != 1.")
-            setsolutionstatus!(cg_optstate, status)
+            setterminationstatus!(cg_optstate, INFEASIBLE)
             return true
         end
 
@@ -689,7 +690,6 @@ function cg_main_loop!(
             if nb_new_col < 0
                 @error "Infeasible subproblem."
                 setterminationstatus!(cg_optstate, INFEASIBLE)
-                setsolutionstatus!(cg_optstate, EMPTY_SOL)
                 return true
             end
 

--- a/src/Algorithm/colgenstabilization.jl
+++ b/src/Algorithm/colgenstabilization.jl
@@ -105,7 +105,7 @@ function linear_combination(in_dual_sol::DualSolution, out_dual_sol::DualSolutio
     for (i, constrid) in enumerate(constrids)
         bound += constrvals[i] * getcurrhs(form, constrid) 
     end
-    return DualSolution(form, constrids, constrvals, bound)
+    return DualSolution(form, constrids, constrvals, bound, FEASIBLE_SOL)
 end
 
 function update_stab_after_rm_solve!(
@@ -144,7 +144,7 @@ function update_alpha_automatically!(
 
     # first we calculate the in-sep direction
     constrids, constrvals = componentwisefunction(smooth_dual_sol, storage.stabcenter, -)
-    in_sep_direction = DualSolution(master, constrids, constrvals, 0.0)
+    in_sep_direction = DualSolution(master, constrids, constrvals, 0.0, FEASIBLE_SOL)
     in_sep_dir_norm = norm(in_sep_direction)
 
     # we initialize the subgradient with the right-hand-side of all master constraints
@@ -158,7 +158,7 @@ function update_alpha_automatically!(
             push!(constrrhs, getcurrhs(master, constrid))
         end 
     end
-    subgradient = DualSolution(master, constrids, constrrhs, 0.0)
+    subgradient = DualSolution(master, constrids, constrrhs, 0.0, FEASIBLE_SOL)
     
     # we calculate the subgradient at the sep point
     for (constrid, value) in subgradient_contribution

--- a/src/Algorithm/colgenstabilization.jl
+++ b/src/Algorithm/colgenstabilization.jl
@@ -105,7 +105,7 @@ function linear_combination(in_dual_sol::DualSolution, out_dual_sol::DualSolutio
     for (i, constrid) in enumerate(constrids)
         bound += constrvals[i] * getcurrhs(form, constrid) 
     end
-    return DualSolution(form, constrids, constrvals, bound, FEASIBLE_SOL)
+    return DualSolution(form, constrids, constrvals, bound, UNKNOWN_FEASIBILITY)
 end
 
 function update_stab_after_rm_solve!(
@@ -144,7 +144,7 @@ function update_alpha_automatically!(
 
     # first we calculate the in-sep direction
     constrids, constrvals = componentwisefunction(smooth_dual_sol, storage.stabcenter, -)
-    in_sep_direction = DualSolution(master, constrids, constrvals, 0.0, FEASIBLE_SOL)
+    in_sep_direction = DualSolution(master, constrids, constrvals, 0.0, UNKNOWN_FEASIBILITY)
     in_sep_dir_norm = norm(in_sep_direction)
 
     # we initialize the subgradient with the right-hand-side of all master constraints
@@ -158,7 +158,7 @@ function update_alpha_automatically!(
             push!(constrrhs, getcurrhs(master, constrid))
         end 
     end
-    subgradient = DualSolution(master, constrids, constrrhs, 0.0, FEASIBLE_SOL)
+    subgradient = DualSolution(master, constrids, constrrhs, 0.0, UNKNOWN_FEASIBILITY)
     
     # we calculate the subgradient at the sep point
     for (constrid, value) in subgradient_contribution

--- a/src/Algorithm/conquer.jl
+++ b/src/Algorithm/conquer.jl
@@ -142,7 +142,7 @@ function run!(algo::ColCutGenConquer, data::ReformData, input::ConquerInput)
     nodestate = getoptstate(node)
     reform = getreform(data)
     if algo.run_preprocessing && isinfeasible(run!(algo.preprocess, data, EmptyInput()))
-        setfeasibilitystatus!(nodestate, INFEASIBLE)
+        setterminationstatus!(nodestate, INFEASIBLE)
         return 
     end
 

--- a/src/Algorithm/node.jl
+++ b/src/Algorithm/node.jl
@@ -59,7 +59,7 @@ setinfeasible(n::Node, status::Bool) = n.infeasible = status
 
 function to_be_pruned(node::Node)
     nodestate = getoptstate(node)
-    isinfeasible(nodestate) && return true
+    getterminationstatus(nodestate) == INFEASIBLE && return true
     bounds_ratio = get_ip_primal_bound(nodestate) / get_ip_dual_bound(nodestate)
     return isapprox(bounds_ratio, 1) || ip_gap(nodestate) < 0
 end

--- a/src/Algorithm/treesearch.jl
+++ b/src/Algorithm/treesearch.jl
@@ -285,10 +285,8 @@ function determine_statuses(data::TreeSearchRuntimeData)
     treestate = getoptstate(data)
     found_sols = (nb_ip_primal_sols(treestate) > 0)
     gap_is_zero = (get_ip_primal_bound(treestate) / get_ip_dual_bound(treestate) ≈ 1.0)
-    found_sols && setsolutionstatus!(treestate, FEASIBLE_SOL)
     gap_is_zero && setterminationstatus!(treestate, OPTIMAL)
     if !found_sols # Implies that gap is not zero
-        setsolutionstatus!(treestate, EMPTY_SOL)
         # Determine if we can prove that is was infeasible
         if fully_explored
             setterminationstatus!(treestate, INFEASIBLE)

--- a/src/Algorithm/treesearch.jl
+++ b/src/Algorithm/treesearch.jl
@@ -285,16 +285,15 @@ function determine_statuses(data::TreeSearchRuntimeData)
     treestate = getoptstate(data)
     found_sols = (nb_ip_primal_sols(treestate) > 0)
     gap_is_zero = (get_ip_primal_bound(treestate) / get_ip_dual_bound(treestate) ≈ 1.0)
-    #gap_is_zero && @assert found_sols
-    found_sols && setfeasibilitystatus!(treestate, FEASIBLE)
+    found_sols && setsolutionstatus!(treestate, FEASIBLE_SOL)
     gap_is_zero && setterminationstatus!(treestate, OPTIMAL)
     if !found_sols # Implies that gap is not zero
-        setterminationstatus!(treestate, EMPTY_RESULT)
+        setsolutionstatus!(treestate, EMPTY_SOL)
         # Determine if we can prove that is was infeasible
         if fully_explored
-            setfeasibilitystatus!(treestate, INFEASIBLE)
+            setterminationstatus!(treestate, INFEASIBLE)
         else
-            setfeasibilitystatus!(treestate, UNKNOWN_FEASIBILITY)
+            setterminationstatus!(treestate, UNCOVERED_TERMINATION_STATUS)
         end
     elseif !gap_is_zero
         setterminationstatus!(treestate, OTHER_LIMIT)

--- a/src/Algorithm/utilities/optimizationstate.jl
+++ b/src/Algorithm/utilities/optimizationstate.jl
@@ -336,7 +336,6 @@ end
 function Base.print(io::IO, form::AbstractFormulation, optstate::OptimizationState)
     println(io, "┌ Optimization state ")
     println(io, "│ Termination status: ", optstate.termination_status)
-    println(io, "│ Solution status: ", optstate.solution_status)
     println(io, "| Incumbents: ", optstate.incumbents)
     n = nb_ip_primal_sols(optstate)
     println(io, "| IP Primal solutions (",n,")")

--- a/src/Algorithm/utilities/optimizationstate.jl
+++ b/src/Algorithm/utilities/optimizationstate.jl
@@ -3,7 +3,6 @@ getvalue(bnd::Bound) = ColunaBase.getvalue(bnd)
 
 mutable struct OptimizationState{F<:AbstractFormulation,S<:Coluna.AbstractSense}
     termination_status::TerminationStatus
-    solution_status::SolutionStatus
     incumbents::ObjValues{S}
     max_length_ip_primal_sols::Int
     max_length_lp_primal_sols::Int
@@ -40,7 +39,6 @@ end
 """
     OptimizationState(
         form; 
-        solution_status = UNKNOWN_SOLUTION_STATUS, 
         termination_status = UNKNOWN_TERMINATION_STATUS,
         ip_primal_bound = nothing, 
         ip_dual_bound = nothing, 
@@ -55,7 +53,7 @@ end
         )
 
 A convenient structure to maintain and return solutions and bounds of a formulation `form` during an
-optimization process. The feasibility and termination statuses are considered as
+optimization process. The termination statuses is considered as
 unknown by default. You can define the initial incumbent bounds using `ip_primal_bound`,
 `ip_dual_bound`, `lp_primal_bound`, and `lp_primal_bound` keyword arguments. Incumbent
 bounds are set to infinite (according to formulation objective sense) by default.
@@ -69,7 +67,6 @@ best bound.
 """
 function OptimizationState(
     form::F;
-    solution_status::SolutionStatus = UNKNOWN_SOLUTION_STATUS,
     termination_status::TerminationStatus = UNKNOWN_TERMINATION_STATUS,
     ip_primal_bound = nothing,
     ip_dual_bound = nothing,
@@ -92,7 +89,6 @@ function OptimizationState(
     S = getobjsense(form)
     state = OptimizationState{F,S}(
         termination_status, 
-        solution_status, 
         incumbents,
         max_length_ip_primal_sols,
         max_length_lp_primal_sols,
@@ -110,7 +106,6 @@ function OptimizationState(
 )
     newor = OptimizationState(
         form,
-        solution_status = getsolutionstatus(or),
         termination_status = getterminationstatus(or),
         ip_primal_bound = get_ip_primal_bound(or),
         ip_dual_bound = get_ip_dual_bound(or),
@@ -136,7 +131,6 @@ function CopyBoundsAndStatusesFromOptState(
 )
     state = OptimizationState(
         form,
-        solution_status = getsolutionstatus(source_state),
         termination_status = getterminationstatus(source_state),
         ip_primal_bound = get_ip_primal_bound(source_state),
         lp_primal_bound = PrimalBound(form),
@@ -150,13 +144,13 @@ function CopyBoundsAndStatusesFromOptState(
 end
 
 getterminationstatus(state::OptimizationState) = state.termination_status
-getsolutionstatus(state::OptimizationState) = state.solution_status
+#getsolutionstatus(state::OptimizationState) = state.solution_status
 
 setterminationstatus!(state::OptimizationState, status::TerminationStatus) = state.termination_status = status
-setsolutionstatus!(state::OptimizationState, status::SolutionStatus) = state.solution_status = status
+#setsolutionstatus!(state::OptimizationState, status::SolutionStatus) = state.solution_status = status
 
-isfeasible(state::OptimizationState) = state.solution_status == FEASIBLE_SOL
-isinfeasible(state::OptimizationState) = state.solution_status == INFEASIBLE_SOL
+#isfeasible(state::OptimizationState) = state.solution_status == FEASIBLE_SOL
+#isinfeasible(state::OptimizationState) = state.solution_status == INFEASIBLE_SOL
 
 getincumbents(state::OptimizationState) = state.incumbents
 
@@ -238,7 +232,6 @@ function update_all_ip_primal_solutions!(
 end
 
 function update!(dest_state::OptimizationState, orig_state::OptimizationState)
-    setsolutionstatus!(dest_state, getsolutionstatus(orig_state))
     setterminationstatus!(dest_state, getterminationstatus(orig_state))
     update_all_ip_primal_solutions!(dest_state, orig_state)
     update_ip_dual_bound!(dest_state, get_ip_dual_bound(orig_state))

--- a/src/Algorithm/utilities/optimizationstate.jl
+++ b/src/Algorithm/utilities/optimizationstate.jl
@@ -39,7 +39,7 @@ end
 
 """
     OptimizationState(
-        form; feasibility_status = UNKNOWN_FEASIBILITY, termination_status = NOT_YET_DETERMINED,
+        form; feasibility_status = UNKNOWN_FEASIBILITY, termination_status = UNKNOWN_TERMINATION,
         ip_primal_bound = nothing, ip_dual_bound = nothing, lp_primal_bound = nothing, lp_dual_bound = nothing,
         max_length_ip_primal_sols = 1, max_length_lp_dual_sols = 1, max_length_lp_dual_sols = 1,
         insert_function_ip_primal_sols = bestbound, insert_function_lp_primal_sols = bestbound, 
@@ -62,7 +62,7 @@ best bound.
 function OptimizationState(
     form::F;
     feasibility_status::FeasibilityStatus = UNKNOWN_FEASIBILITY,
-    termination_status::TerminationStatus = NOT_YET_DETERMINED,
+    termination_status::TerminationStatus = UNKNOWN_TERMINATION,
     ip_primal_bound = nothing,
     ip_dual_bound = nothing,
     lp_primal_bound = nothing,

--- a/src/ColunaBase/ColunaBase.jl
+++ b/src/ColunaBase/ColunaBase.jl
@@ -15,6 +15,11 @@ export NestedEnum, @nestedenum, @exported_nestedenum
 # solsandbounds.jl
 export Bound, Solution, getvalue, isbetter, diff, gap, printbounds, getsol, remove_until_last_point
 
+# Statuses
+export TerminationStatus, SolutionStatus, MoiResult, OPTIMAL, INFEASIBLE, TIME_LIMIT, 
+    NODE_LIMIT, OTHER_LIMIT, UNKNOWN_TERMINATION_STATUS, UNCOVERED_TERMINATION_STATUS, 
+    FEASIBLE_SOL, INFEASIBLE_SOL, UNKNOWN_SOLUTION_STATUS, UNCOVERED_SOLUTION_STATUS
+
 include("interface.jl")
 include("nestedenum.jl")
 include("solsandbounds.jl")

--- a/src/ColunaBase/ColunaBase.jl
+++ b/src/ColunaBase/ColunaBase.jl
@@ -18,7 +18,8 @@ export Bound, Solution, getvalue, isbetter, diff, gap, printbounds, getsol, remo
 # Statuses
 export TerminationStatus, SolutionStatus, MoiResult, OPTIMAL, INFEASIBLE, TIME_LIMIT, 
     NODE_LIMIT, OTHER_LIMIT, UNKNOWN_TERMINATION_STATUS, UNCOVERED_TERMINATION_STATUS, 
-    FEASIBLE_SOL, INFEASIBLE_SOL, UNKNOWN_SOLUTION_STATUS, UNCOVERED_SOLUTION_STATUS
+    FEASIBLE_SOL, INFEASIBLE_SOL, UNKNOWN_FEASIBILITY, UNKNOWN_SOLUTION_STATUS, 
+    UNCOVERED_SOLUTION_STATUS
 
 include("interface.jl")
 include("nestedenum.jl")

--- a/src/ColunaBase/nestedenum.jl
+++ b/src/ColunaBase/nestedenum.jl
@@ -99,7 +99,7 @@ function _build_print_expression(names, values)
     push!(print_expr.args, :(Base.print(io::IO, obj::$(root_name)))) #signature
 
     # build the if list in reverse order
-    prev_cond = :(print(io, "UNKOWN_DUTY"))
+    prev_cond = :(print(io, "UNKNOWN_DUTY"))
     for i in length(names):-1:2
         head = (i == 2) ? :if : :elseif
         msg = string(names[i])

--- a/src/ColunaBase/solsandbounds.jl
+++ b/src/ColunaBase/solsandbounds.jl
@@ -160,7 +160,7 @@ If the subsolver called through MOI returns a
 todo
 """
 @enum(
-    SolutionStatus, FEASIBLE_SOL, INFEASIBLE_SOL, UNKNOWN_SOLUTION_STATUS,
+    SolutionStatus, FEASIBLE_SOL, INFEASIBLE_SOL, UNKNOWN_FEASIBILITY, UNKNOWN_SOLUTION_STATUS,
     UNCOVERED_SOLUTION_STATUS
 )
 

--- a/src/MOIcallbacks.jl
+++ b/src/MOIcallbacks.jl
@@ -33,8 +33,7 @@ function MOI.submit(
     push!(values, 1.0)
     solval += getcurcost(form, setup_var_id)
 
-    add_primal_sol!(result, PrimalSolution(form, colunavarids, values, solval))
-    setsolutionstatus!(result, FEASIBLE_SOL)
+    add_primal_sol!(result, PrimalSolution(form, colunavarids, values, solval, FEASIBLE_SOL))
     setterminationstatus!(result, OPTIMAL)
     cb.callback_data.result = result
     return

--- a/src/MOIcallbacks.jl
+++ b/src/MOIcallbacks.jl
@@ -34,7 +34,7 @@ function MOI.submit(
     solval += getcurcost(form, setup_var_id)
 
     add_primal_sol!(result, PrimalSolution(form, colunavarids, values, solval))
-    setfeasibilitystatus!(result, FEASIBLE)
+    setsolutionstatus!(result, FEASIBLE_SOL)
     setterminationstatus!(result, OPTIMAL)
     cb.callback_data.result = result
     return

--- a/src/MOIwrapper.jl
+++ b/src/MOIwrapper.jl
@@ -533,14 +533,5 @@ function MOI.get(optimizer::Optimizer, ::MOI.VariablePrimal, refs::Vector{MOI.Va
 end
 
 function MOI.get(optimizer::Optimizer, object::MOI.TerminationStatus)
-    result = optimizer.result
-    isfeasible(result) && return MathProg.convert_status(getterminationstatus(result))
-    getfeasibilitystatus(result) == INFEASIBLE && return MOI.INFEASIBLE
-    getfeasibilitystatus(result) == UNKNOWN_FEASIBILITY && return MOI.OTHER_LIMIT
-    error(string(
-        "Could not determine MOI status. Coluna termination : ",
-        getterminationstatus(result), ". Coluna feasibility : ",
-        getfeasibilitystatus(result)
-    ))
-    return
+    return MathProg.convert_status(getterminationstatus(optimizer.result))
 end

--- a/src/MathProg/MOIinterface.jl
+++ b/src/MathProg/MOIinterface.jl
@@ -182,9 +182,9 @@ function _getcolunakind(record::MoiVarRecord)
     return Integ
 end
 
-function fill_primal_result!(form::Formulation, optimizer::MoiOptimizer, 
-                             result::MoiResult{<:Formulation,S},
-                             ) where {S<:Coluna.AbstractSense}
+function fill_primal_result!(
+    form::Formulation, optimizer::MoiOptimizer, result::MoiResult{<:Formulation,S}
+) where {S<:Coluna.AbstractSense}
     inner = getinner(optimizer)
     for res_idx in 1:MOI.get(inner, MOI.ResultCount())
         if MOI.get(inner, MOI.PrimalStatus(res_idx)) != MOI.FEASIBLE_POINT
@@ -206,15 +206,15 @@ function fill_primal_result!(form::Formulation, optimizer::MoiOptimizer,
                 push!(solvals, val)
             end
         end
-        add_primal_sol!(result, PrimalSolution(form, solvars, solvals, solcost))
+        add_primal_sol!(result, PrimalSolution(form, solvars, solvals, solcost, FEASIBLE_SOL))
     end
     @logmsg LogLevel(-2) string("Primal bound is ", getprimalbound(result))
     return
 end
 
-function fill_dual_result!(form::Formulation, optimizer::MoiOptimizer,
-                           result::MoiResult{<:Formulation,S}
-                           ) where {S<:Coluna.AbstractSense}
+function fill_dual_result!(
+    form::Formulation, optimizer::MoiOptimizer, result::MoiResult{<:Formulation,S}
+) where {S<:Coluna.AbstractSense}
     inner = getinner(optimizer)
     for res_idx in 1:MOI.get(inner, MOI.ResultCount())
         if MOI.get(inner, MOI.DualStatus(res_idx)) != MOI.FEASIBLE_POINT
@@ -236,7 +236,7 @@ function fill_dual_result!(form::Formulation, optimizer::MoiOptimizer,
                 push!(solvals, val)      
             end
         end
-        add_dual_sol!(result, DualSolution(form, solconstrs, solvals, solcost))
+        add_dual_sol!(result, DualSolution(form, solconstrs, solvals, solcost, FEASIBLE_SOL))
     end
     @logmsg LogLevel(-2) string("Dual bound is ", getdualbound(result))
     return

--- a/src/MathProg/MathProg.jl
+++ b/src/MathProg/MathProg.jl
@@ -103,10 +103,11 @@ export Variable, Constraint, VarId, ConstrId, VarMembership, ConstrMembership,
 # Types & methods related to solutions & bounds
 # Note : we should export only get methods for MoiResult (the solution is built in MathProg)
 export PrimalBound, DualBound, PrimalSolution, DualSolution, ObjValues, TerminationStatus,
-    FeasibilityStatus, MoiResult, OPTIMAL, TIME_LIMIT, NODE_LIMIT, OTHER_LIMIT,
-    EMPTY_RESULT, UNKNOWN_TERMINATION, UNDEFINED, INFEASIBLE, UNKNOWN_FEASIBILITY, FEASIBLE,
-    getterminationstatus, getfeasibilitystatus, setterminationstatus!,
-    setfeasibilitystatus!, isfeasible, get_ip_primal_bound, get_lp_primal_bound,
+    SolutionStatus, MoiResult, OPTIMAL, INFEASIBLE, TIME_LIMIT, NODE_LIMIT, OTHER_LIMIT,
+    UNKNOWN_TERMINATION_STATUS, UNCOVERED_TERMINATION_STATUS, FEASIBLE_SOL, INFEASIBLE_SOL, 
+    EMPTY_SOL, UNKNOWN_SOLUTION_STATUS, UNCOVERED_SOLUTION_STATUS,
+    getterminationstatus, getsolutionstatus, setterminationstatus!,
+    setsolutionstatus!, isfeasible, get_ip_primal_bound, get_lp_primal_bound,
     get_ip_dual_bound, get_lp_dual_bound, update_ip_primal_bound!, update_lp_primal_bound!,
     update_ip_dual_bound!, update_lp_dual_bound!, set_ip_primal_bound!,
     set_lp_primal_bound!, set_ip_dual_bound!, set_lp_dual_bound!, ip_gap

--- a/src/MathProg/MathProg.jl
+++ b/src/MathProg/MathProg.jl
@@ -104,7 +104,7 @@ export Variable, Constraint, VarId, ConstrId, VarMembership, ConstrMembership,
 # Note : we should export only get methods for MoiResult (the solution is built in MathProg)
 export PrimalBound, DualBound, PrimalSolution, DualSolution, ObjValues, TerminationStatus,
     FeasibilityStatus, MoiResult, OPTIMAL, TIME_LIMIT, NODE_LIMIT, OTHER_LIMIT,
-    EMPTY_RESULT, NOT_YET_DETERMINED, INFEASIBLE, UNKNOWN_FEASIBILITY, FEASIBLE,
+    EMPTY_RESULT, UNKNOWN_TERMINATION, UNDEFINED, INFEASIBLE, UNKNOWN_FEASIBILITY, FEASIBLE,
     getterminationstatus, getfeasibilitystatus, setterminationstatus!,
     setfeasibilitystatus!, isfeasible, get_ip_primal_bound, get_lp_primal_bound,
     get_ip_dual_bound, get_lp_dual_bound, update_ip_primal_bound!, update_lp_primal_bound!,

--- a/src/MathProg/MathProg.jl
+++ b/src/MathProg/MathProg.jl
@@ -102,12 +102,9 @@ export Variable, Constraint, VarId, ConstrId, VarMembership, ConstrMembership,
 
 # Types & methods related to solutions & bounds
 # Note : we should export only get methods for MoiResult (the solution is built in MathProg)
-export PrimalBound, DualBound, PrimalSolution, DualSolution, ObjValues, TerminationStatus,
-    SolutionStatus, MoiResult, OPTIMAL, INFEASIBLE, TIME_LIMIT, NODE_LIMIT, OTHER_LIMIT,
-    UNKNOWN_TERMINATION_STATUS, UNCOVERED_TERMINATION_STATUS, FEASIBLE_SOL, INFEASIBLE_SOL, 
-    EMPTY_SOL, UNKNOWN_SOLUTION_STATUS, UNCOVERED_SOLUTION_STATUS,
-    getterminationstatus, getsolutionstatus, setterminationstatus!,
-    setsolutionstatus!, isfeasible, get_ip_primal_bound, get_lp_primal_bound,
+export PrimalBound, DualBound, PrimalSolution, DualSolution, ObjValues, MoiResult,
+    getterminationstatus, setterminationstatus!,
+    get_ip_primal_bound, get_lp_primal_bound,
     get_ip_dual_bound, get_lp_dual_bound, update_ip_primal_bound!, update_lp_primal_bound!,
     update_ip_dual_bound!, update_lp_dual_bound!, set_ip_primal_bound!,
     set_lp_primal_bound!, set_ip_dual_bound!, set_lp_dual_bound!, ip_gap

--- a/src/MathProg/optimizerwrappers.jl
+++ b/src/MathProg/optimizerwrappers.jl
@@ -1,4 +1,32 @@
-@enum(TerminationStatus, OPTIMAL, TIME_LIMIT, NODE_LIMIT, OTHER_LIMIT, EMPTY_RESULT, NOT_YET_DETERMINED)
+"""
+    TerminationStatus
+
+Theses statuses are the possible reasons why the solver stopped the optimization. 
+When a subsolver is called through MOI, the
+MOI [`TerminationStatusCode`](https://jump.dev/MathOptInterface.jl/stable/apireference/#MathOptInterface.TerminationStatusCode)
+is translated into a Coluna `TerminationStatus`.
+
+Description of the termination statuses: 
+- `OPTIMAL` : the algorithm found a global optimal solution given the optimality tolerance.
+- `TIME_LIMIT` : the algorithm stopped because of the time limit
+- `NODE_LIMIT` : the branch-and-bound based algorithm stopped due to the node limit
+- `OTHER_LIMIT` : the algorithm stopped because of a limit that is neither the time limit 
+nor the node limit
+- `EMPTY_RESULT` : the algorithm finished but there is no result (if the problem is infeasible for example)
+
+If the algorithm has not been called, the default value of the termination status should be:
+- `UNKNOWN_TERMINATION`
+
+If the subsolver called through MOI returns a 
+`TerminationStatusCode` that is not `MOI.OPTIMAL`, `MOI.TIME_LIMIT`, `MOI.NODE_LIMIT`, or 
+`MOI.OTHER_LIMIT`:
+- `UNDEFINED` : should not be used by a Coluna algorithm
+"""
+@enum(TerminationStatus, OPTIMAL, TIME_LIMIT, NODE_LIMIT, OTHER_LIMIT, EMPTY_RESULT, UNKNOWN_TERMINATION, UNDEFINED)
+
+"""
+    FeasibilityStatus
+"""
 @enum(FeasibilityStatus, FEASIBLE, INFEASIBLE, UNKNOWN_FEASIBILITY)
 
 function convert_status(moi_status::MOI.TerminationStatusCode)
@@ -6,7 +34,7 @@ function convert_status(moi_status::MOI.TerminationStatusCode)
     moi_status == MOI.TIME_LIMIT && return TIME_LIMIT
     moi_status == MOI.NODE_LIMIT && return NODE_LIMIT
     moi_status == MOI.OTHER_LIMIT && return OTHER_LIMIT
-    return NOT_YET_DETERMINED
+    return UNDEFINED
 end
 
 function convert_status(coluna_status::TerminationStatus)
@@ -32,7 +60,7 @@ end
 function MoiResult(model::M) where {M<:AbstractModel}
     S = getobjsense(model)
     return MoiResult{M,S}(
-        NOT_YET_DETERMINED, UNKNOWN_FEASIBILITY, PrimalBound(model),
+        UNKNOWN_TERMINATION, UNKNOWN_FEASIBILITY, PrimalBound(model),
         DualBound(model),
         PrimalSolution{M}[], DualSolution{M}[]
     )

--- a/src/MathProg/projection.jl
+++ b/src/MathProg/projection.jl
@@ -20,7 +20,7 @@ function proj_cols_on_rep(sol::PrimalSolution, master::Formulation{DwMaster})
             end
         end
     end
-    return PrimalSolution(master, projected_sol_vars, projected_sol_vals, getvalue(sol))
+    return PrimalSolution(master, projected_sol_vars, projected_sol_vals, getvalue(sol), FEASIBLE_SOL)
 end
 
 projection_is_possible(master::Formulation{BendersMaster}) = false

--- a/src/MathProg/solutions.jl
+++ b/src/MathProg/solutions.jl
@@ -9,9 +9,9 @@ function PrimalSolution(form::M) where {M}
 end
 
 function PrimalSolution(
-    form::M, decisions::Vector{De}, vals::Vector{Va}, val::Float64
+    form::M, decisions::Vector{De}, vals::Vector{Va}, val::Float64, status::SolutionStatus
 ) where {M<:AbstractFormulation,De,Va}
-    return Solution{M,De,Va}(form, decisions, vals, val)
+    return Solution{M,De,Va}(form, decisions, vals, val, status)
 end
 
 function DualSolution(form::M) where {M}
@@ -19,9 +19,9 @@ function DualSolution(form::M) where {M}
 end
 
 function DualSolution(
-    form::M, decisions::Vector{De}, vals::Vector{Va}, val::Float64
+    form::M, decisions::Vector{De}, vals::Vector{Va}, val::Float64, status::SolutionStatus
 ) where {M<:AbstractFormulation,De,Va}
-    return Solution{M,De,Va}(form, decisions, vals, val)
+    return Solution{M,De,Va}(form, decisions, vals, val, status)
 end
 
 function Base.isinteger(sol::Solution)

--- a/src/optimize.jl
+++ b/src/optimize.jl
@@ -101,7 +101,7 @@ function optimize!(
     # we copy optimisation state as we want to project the solution to the compact space
     outstate = OptimizationState(
         master,
-        feasibility_status = getfeasibilitystatus(algstate),
+        solution_status = getsolutionstatus(algstate),
         termination_status = getterminationstatus(algstate),
         ip_primal_bound = get_ip_primal_bound(algstate),
         ip_dual_bound = get_ip_dual_bound(algstate),

--- a/src/optimize.jl
+++ b/src/optimize.jl
@@ -101,7 +101,6 @@ function optimize!(
     # we copy optimisation state as we want to project the solution to the compact space
     outstate = OptimizationState(
         master,
-        solution_status = getsolutionstatus(algstate),
         termination_status = getterminationstatus(algstate),
         ip_primal_bound = get_ip_primal_bound(algstate),
         ip_dual_bound = get_ip_dual_bound(algstate),

--- a/test/unit/containers/solsandbounds.jl
+++ b/test/unit/containers/solsandbounds.jl
@@ -217,7 +217,7 @@ function solution_unit()
     Solution = Coluna.ColunaBase.Solution{FakeModel,Int,Float64}
 
     dict_sol, soldecs, solvals = fake_solution_factory(100)
-    primal_sol = Solution(model, soldecs, solvals, 12.3)
+    primal_sol = Solution(model, soldecs, solvals, 12.3, Coluna.ColunaBase.FEASIBLE_SOL)
     test_solution_iterations(primal_sol, dict_sol)
     @test Coluna.ColunaBase.getvalue(primal_sol) == 12.3
     #Coluna.ColunaBase.setvalue!(primal_sol, 123.4)


### PR DESCRIPTION

I kept `NODE_LIMIT` because it can be usefull when we call subsolvers through MOI, or when we only solve the root node.

I replaced `NOT_YET_DETERMINED`  by  `UNKOWN_TERMINATION` (symmetric to `UNKNOWN_FEASIBILITY`) & `UNDEFINED`.
