### PR TITLE
SolveIpForm & SolveLpForm refactoring

### DIFF
--- a/src/Algorithm/basic/solveipform.jl
+++ b/src/Algorithm/basic/solveipform.jl
@@ -135,6 +135,7 @@ function optimize_with_moi!(optimizer::MoiOptimizer, form::Formulation, result::
     else
         MOI.optimize!(getinner(optimizer))
     end
+    termination_status!(result, optimizer)
     return
 end
 
@@ -154,7 +155,6 @@ function optimize_ip_form!(
     end
 
     optimize_with_moi!(optimizer, form, result)
-    termination_status!(result, optimizer)
     primal_sols = get_primal_solutions(form, optimizer)
 
     if algo.enforce_integrality

--- a/src/Algorithm/basic/solvelpform.jl
+++ b/src/Algorithm/basic/solvelpform.jl
@@ -46,11 +46,11 @@ end
 function optimize_lp_form!(algo::SolveLpForm, optimizer::MoiOptimizer, form::Formulation)
     MOI.set(form.optimizer.inner, MOI.Silent(), algo.silent)
     result = OptimizationState(form)
-    sols_found =  optimize_with_moi!(optimizer, form, result)
-    if sols_found
-        for primal_sol in get_primal_solutions(form, optimizer)
-            add_lp_primal_sol!(result, primal_sol)
-        end
+    optimize_with_moi!(optimizer, form, result)
+    for primal_sol in get_primal_solutions(form, optimizer)
+        add_lp_primal_sol!(result, primal_sol)
+    end
+    if algo.get_dual_solution
         for dual_sol in get_dual_solutions(form, optimizer)
             add_lp_dual_sol!(result, dual_sol)
         end

--- a/src/Algorithm/branching/branchingalgo.jl
+++ b/src/Algorithm/branching/branchingalgo.jl
@@ -223,8 +223,8 @@ function run!(algo::StrongBranching, data::ReformData, input::DivideInput)::Divi
     # we obtain the original and extended solutions
     reform = getreform(data)
     master = getmaster(reform)
-    original_solution = PrimalSolution(getmaster(reform))
-    extended_solution = PrimalSolution(getmaster(reform))
+    original_solution = nothing
+    extended_solution = nothing
     if nb_lp_primal_sols(optstate) > 0
         if projection_is_possible(master)
             extended_solution = get_best_lp_primal_sol(optstate)
@@ -270,7 +270,7 @@ function run!(algo::StrongBranching, data::ReformData, input::DivideInput)::Divi
         append!(kept_branch_groups, output.groups)
         local_id = output.local_id
 
-        if projection_is_possible(master)
+        if projection_is_possible(master) && extended_solution !== nothing
             output = run!(rule, data, BranchingRuleInput(
                 extended_solution, false, nb_candidates_needed, algo.selection_criterion, 
                 local_id, algo.int_tol

--- a/src/Coluna.jl
+++ b/src/Coluna.jl
@@ -28,7 +28,7 @@ export Parameters, DefaultOptimizer
 # Base functions for which we define more methods in Coluna
 import Base: isempty, hash, isequal, length, iterate, getindex, lastindex,
     getkey, delete!, setindex!, haskey, copy, promote_rule, convert, isinteger,
-    push!, filter, diff
+    push!, filter, diff, hcat
 
 include("interface.jl")
 include("parameters.jl")

--- a/src/ColunaBase/solsandbounds.jl
+++ b/src/ColunaBase/solsandbounds.jl
@@ -179,14 +179,8 @@ end
 """
     Solution
 
-Should be used like a dict
-doc todo
+doc todo. Solution is immutable.
 """
-function Solution{Mo,De,Va}(model::Mo) where {Mo<:AbstractModel,De,Va}
-    sol = DynamicSparseArrays.dynamicsparsevec(De[], Va[])
-    return Solution(model, NaN, UNKNOWN_SOLUTION_STATUS, sol)
-end
-
 function Solution{Mo,De,Va}(model::Mo, decisions::Vector{De}, vals::Vector{Va}, value::Float64, status::SolutionStatus) where {Mo<:AbstractModel,De,Va}
     sol = DynamicSparseArrays.dynamicsparsevec(decisions, vals)
     return Solution(model, value, status, sol)

--- a/src/MathProg/MathProg.jl
+++ b/src/MathProg/MathProg.jl
@@ -61,7 +61,7 @@ export no_optimizer_builder, set_original_formulation!,
        find_owner_formulation,
        getsortuid,
        contains, setprimalbound!, get_original_formulation,
-       concatenate_sols, getoriginformuid, getspsol, sync_solver!, getinner,
+       getoriginformuid, getspsol, sync_solver!, getinner,
        get_primal_solutions, get_dual_solutions
 
 # Below this line, clean up has been done :
@@ -98,7 +98,7 @@ export Variable, Constraint, VarId, ConstrId, VarMembership, ConstrMembership,
     isexplicit, getname, reset!, getreducedcost
 
 # Types & methods related to solutions & bounds
-export PrimalBound, DualBound, PrimalSolution, EmptyPrimalSolution, DualSolution, ObjValues,
+export PrimalBound, DualBound, PrimalSolution, DualSolution, ObjValues,
     get_ip_primal_bound, get_lp_primal_bound,
     get_ip_dual_bound, get_lp_dual_bound, update_ip_primal_bound!, update_lp_primal_bound!,
     update_ip_dual_bound!, update_lp_dual_bound!, set_ip_primal_bound!,

--- a/src/MathProg/solutions.jl
+++ b/src/MathProg/solutions.jl
@@ -51,10 +51,10 @@ end
 function Base.cat(sols::Solution{M, I, Float64}...) where {M,I}
     _assert_same_model(sols) || error("Cannot concatenate solutions not attached to the same model.")
 
-    ids = VarId[]
+    ids = I[]
     vals = Float64[]
-    for sol in sols, (varid, value) in sol
-        push!(ids, varid)
+    for sol in sols, (id, value) in sol
+        push!(ids, id)
         push!(vals, value)
     end
 

--- a/src/MathProg/solutions.jl
+++ b/src/MathProg/solutions.jl
@@ -4,22 +4,10 @@
 const PrimalSolution{M} = Solution{M, VarId, Float64}
 const DualSolution{M} = Solution{M, ConstrId, Float64}
 
-function PrimalSolution(form::M) where {M}
-    return Solution{M,VarId,Float64}(form)
-end
-
 function PrimalSolution(
     form::M, decisions::Vector{De}, vals::Vector{Va}, val::Float64, status::SolutionStatus
 ) where {M<:AbstractFormulation,De,Va}
     return Solution{M,De,Va}(form, decisions, vals, val, status)
-end
-
-function EmptyPrimalSolution(form::M) where {M}
-    return Solution{M,VarId,Float64}(form, VarId[], Float64[], 0.0, UNKNOWN_FEASIBILITY)
-end
-
-function DualSolution(form::M) where {M}
-    return Solution{M,ConstrId,Float64}(form)
 end
 
 function DualSolution(
@@ -53,21 +41,25 @@ function contains(sol::DualSolution, f::Function)
     return false
 end
 
-function concatenate_sols(sola::PrimalSolution{M}, solb::PrimalSolution{M}) where {M}
-    length(solb) == 0 && return sola
+function _assert_same_model(sols::NTuple{N, Solution{M, I, Float64}}) where {N,M,I}
+    for i in 2:length(sols)
+        sols[i-1].model != sols[i].model && return false
+    end
+    return true
+end
 
-    ids = Vector{VarId}()
-    vals = Vector{Float64}()
-    for (varid, value) in sola
+function Base.cat(sols::Solution{M, I, Float64}...) where {M,I}
+    _assert_same_model(sols) || error("Cannot concatenate solutions not attached to the same model.")
+
+    ids = VarId[]
+    vals = Float64[]
+    for sol in sols, (varid, value) in sol
         push!(ids, varid)
         push!(vals, value)
     end
-    for (varid, value) in solb
-        push!(ids, varid)
-        push!(vals, value)
-    end
-    return Solution{M,VarId,Float64}(
-        sola.model, ids, vals, getvalue(sola) + getvalue(solb), sola.status
+
+    return Solution{M,I,Float64}(
+        sols[1].model, ids, vals, sum(getvalue.(sols)), sols[1].status
     )
 end
 


### PR DESCRIPTION
- it's not possible to create "empty solution" anymore, it's better to use `nothing` if there is no solution.
- use of only one `OptimizationState` in `SolveIpForm` & `SolveLpForm` instead of two.
- take into account param `get_dual_solutions` in `SolveLpForm`
- `concatenate_sols` becomes `cat` and supports both primal & dual solutions
