### PR TITLE
gap limit + improve comparison of bounds + MOI.RelativeGap

### DIFF
--- a/src/Algorithm/conquer.jl
+++ b/src/Algorithm/conquer.jl
@@ -45,14 +45,15 @@ exploits_primal_solutions(algo::AbstractConquerAlgorithm) = false
 
 # returns the optimization part of the output of the conquer algorithm 
 function apply_conquer_alg_to_node!(
-    node::Node, algo::AbstractConquerAlgorithm, data::ReformData, storages_to_restore::StoragesUsageDict
-)  
+    node::Node, algo::AbstractConquerAlgorithm, data::ReformData, storages_to_restore::StoragesUsageDict,
+    opt_rtol::Float64 = Coluna.DEF_OPTIMALITY_RTOL
+)
     nodestate = getoptstate(node)
     if isverbose(algo)
         @logmsg LogLevel(-1) string("Node IP DB: ", get_ip_dual_bound(nodestate))
         @logmsg LogLevel(-1) string("Tree IP PB: ", get_ip_primal_bound(nodestate))
     end
-    if ip_gap_closed(nodestate)
+    if ip_gap_closed(nodestate, rtol = opt_rtol)
         @info "IP Gap is closed: $(ip_gap(getincumbents(nodestate))). Abort treatment."
     else
         isverbose(algo) && @logmsg LogLevel(-1) string("IP Gap is positive. Need to treat node.")
@@ -258,4 +259,3 @@ function run!(algo::RestrMasterLPConquer, data::ReformData, input::ConquerInput)
     end
     return
 end
-

--- a/src/Algorithm/conquer.jl
+++ b/src/Algorithm/conquer.jl
@@ -46,14 +46,14 @@ exploits_primal_solutions(algo::AbstractConquerAlgorithm) = false
 # returns the optimization part of the output of the conquer algorithm 
 function apply_conquer_alg_to_node!(
     node::Node, algo::AbstractConquerAlgorithm, data::ReformData, storages_to_restore::StoragesUsageDict,
-    opt_rtol::Float64 = Coluna.DEF_OPTIMALITY_RTOL
+    opt_rtol::Float64 = Coluna.DEF_OPTIMALITY_RTOL, opt_atol::Float64 = Coluna.DEF_OPTIMALITY_ATOL
 )
     nodestate = getoptstate(node)
     if isverbose(algo)
         @logmsg LogLevel(-1) string("Node IP DB: ", get_ip_dual_bound(nodestate))
         @logmsg LogLevel(-1) string("Tree IP PB: ", get_ip_primal_bound(nodestate))
     end
-    if ip_gap_closed(nodestate, rtol = opt_rtol)
+    if ip_gap_closed(nodestate, rtol = opt_rtol, atol = opt_atol)
         @info "IP Gap is closed: $(ip_gap(getincumbents(nodestate))). Abort treatment."
     else
         isverbose(algo) && @logmsg LogLevel(-1) string("IP Gap is positive. Need to treat node.")

--- a/src/Algorithm/treesearch.jl
+++ b/src/Algorithm/treesearch.jl
@@ -23,7 +23,8 @@ getnodevalue(algo::BestDualBoundStrategy, n::Node) = get_ip_dual_bound(getincumb
         explorestrategy::AbstractTreeExploreStrategy = DepthFirstStrategy(),
         maxnumnodes::Int = 100000,
         opennodeslimit::Int = 100,
-        gap_limit::Float64 = DEF_OPTIMALITY_RTOL,
+        opt_atol::Float64 = DEF_OPTIMALITY_ATOL,
+        opt_rtol::Float64 = DEF_OPTIMALITY_RTOL,
         branchingtreefile = nothing
     )
 
@@ -34,7 +35,8 @@ to select the next node to treat.
 Parameters : 
 - `maxnumnodes` : maximum number of nodes explored by the algorithm
 - `opennodeslimit` : maximum number of nodes waiting to be explored.
-- `gap_limit` : gap limit to stop the algorithm
+- `opt_atol` : optimality absolute tolerance
+- `opt_rtol` : optimality relative tolerance
 
 Options :
 - `branchingtreefile` : name of the file in which the algorithm writes an overview of the
@@ -46,7 +48,8 @@ branching tree
     explorestrategy::AbstractTreeExploreStrategy = DepthFirstStrategy()
     maxnumnodes::Int64 = 100000 
     opennodeslimit::Int64 = 100 
-    gap_limit::Float64 = Coluna.DEF_OPTIMALITY_RTOL
+    opt_atol::Float64 = Coluna.DEF_OPTIMALITY_ATOL
+    opt_rtol::Float64 = Coluna.DEF_OPTIMALITY_RTOL
     branchingtreefile::Union{Nothing, String} = nothing
     skiprootnodeconquer = false # true for diving heuristics
     storelpsolution = false
@@ -242,7 +245,7 @@ function run_conquer_algorithm!(
     nodestate = getoptstate(node)
     update_ip_primal!(nodestate, treestate, tsdata.exploitsprimalsolutions)
 
-    apply_conquer_alg_to_node!(node, algo.conqueralg, rfdata, tsdata.conquer_storages_to_restore, algo.gap_limit)        
+    apply_conquer_alg_to_node!(node, algo.conqueralg, rfdata, tsdata.conquer_storages_to_restore, algo.opt_rtol, algo.opt_atol)        
 
     update_all_ip_primal_solutions!(treestate, nodestate)
     
@@ -317,7 +320,7 @@ function run!(algo::TreeSearchAlgorithm, rfdata::ReformData, input::Optimization
         # dual bound of the optstate only at the root node.
         run_conquer_algorithm!(algo, tsdata, rfdata, node)
        
-        if getterminationstatus(node.optstate) == OPTIMAL || ip_gap_closed(node.optstate, rtol = algo.gap_limit)
+        if getterminationstatus(node.optstate) == OPTIMAL || ip_gap_closed(node.optstate, rtol = algo.opt_rtol, atol = algo.opt_atol)
             println("Node is already conquered. No children will be generated.")
             db = get_ip_dual_bound(node.optstate)
             if isbetter(tsdata.worst_db_of_pruned_node, db)
@@ -337,7 +340,7 @@ function run!(algo::TreeSearchAlgorithm, rfdata::ReformData, input::Optimization
 
     if treeisempty(tsdata) # it means that the BB tree has been fully explored
         if nb_ip_primal_sols(tsdata.optstate) >= 1
-            if ip_gap_closed(tsdata.optstate) # TODO : add TreeSearch opt tolerances ?
+            if ip_gap_closed(tsdata.optstate, rtol = algo.opt_rtol, atol = algo.opt_atol)
                 setterminationstatus!(tsdata.optstate, OPTIMAL)
             else
                 setterminationstatus!(tsdata.optstate, OTHER_LIMIT)

--- a/src/MOIwrapper.jl
+++ b/src/MOIwrapper.jl
@@ -511,6 +511,10 @@ function MOI.get(optimizer::Optimizer, ::MOI.ObjectiveValue)
     return getvalue(get_ip_primal_bound(optimizer.result))
 end
 
+function MOI.get(optimizer::Optimizer, ::MOI.RelativeGap)
+    return ip_gap(optimizer.result)
+end
+
 function MOI.get(optimizer::Optimizer, ::MOI.VariablePrimal, ref::MOI.VariableIndex)
     id = getid(optimizer.vars[ref]) # This gets a coluna Id{Variable}
     best_primal_sol = get_best_ip_primal_sol(optimizer.result)

--- a/src/MathProg/bounds.jl
+++ b/src/MathProg/bounds.jl
@@ -116,22 +116,25 @@ lp_gap(ov::ObjValues) = gap(get_lp_primal_bound(ov), get_lp_dual_bound(ov))
 function ip_gap_closed(
     ov::ObjValues; atol = Coluna.DEF_OPTIMALITY_ATOL, rtol = Coluna.DEF_OPTIMALITY_RTOL
 )
-    closed = ip_gap(ov) <= 0
-    closed = closed || isapprox(
+    return (ip_gap(ov) <= 0) || _gap_closed(
         get_ip_primal_bound(ov).value, get_ip_dual_bound(ov).value, atol = atol, rtol = rtol
     )
-    return closed
 end
 
 "Return true if the gap between the best primal and dual bounds of the linear program is closed given optimality tolerances."
 function lp_gap_closed(
     ov::ObjValues; atol = Coluna.DEF_OPTIMALITY_ATOL, rtol = Coluna.DEF_OPTIMALITY_RTOL
 )
-    closed = lp_gap(ov) <= 0
-    closed = closed || isapprox(
+    return (lp_gap(ov) <= 0) || _gap_closed(
         get_lp_primal_bound(ov).value, get_lp_dual_bound(ov).value, atol = atol, rtol = rtol
     )
-    return closed
+end
+
+function _gap_closed(
+    x::Number, y::Number; atol::Real = 0, rtol::Real = atol > 0 ? 0 : √eps, 
+    norm::Function = abs
+) 
+    return (x == y) || (isfinite(x) && isfinite(y) && norm(x - y) <= max(atol, rtol*min(norm(x), norm(y))))
 end
 
 function set_lp_primal_bound!(ov::ObjValues{S}, b::PrimalBound{S}) where {S}

--- a/test/full_instances_tests.jl
+++ b/test/full_instances_tests.jl
@@ -52,7 +52,7 @@ function generalized_assignment_tests()
         @test JuMP.termination_status(model) == MOI.OPTIMAL
         @test CLD.GeneralizedAssignment.print_and_check_sol(data, model, x)
     end
-
+    
     @testset "gap - strong branching" begin
         data = CLD.GeneralizedAssignment.data("mediumgapcuts3.txt")
 


### PR DESCRIPTION
Fix #417 

- gap limit of `TreeSearchAlgorithm`
- fix comparisons of bounds : replace `isapprox = |lb - ub| / max(lb, ub) < rtol` by `_gap_closed = |lb - ub| / min(lb, ub) < rtol`
- `MOI.RelativeGap` now available
