### PR TITLE
Renaming in storage

### DIFF
--- a/src/Algorithm/interface.jl
+++ b/src/Algorithm/interface.jl
@@ -163,7 +163,7 @@ function initialize_storage_units!(data::AbstractData, algo::AbstractOptimizatio
         for type_pair in type_pair_set
             (StorageUnitType, RecordType) = type_pair
             storagedict[type_pair] = 
-                Storage{ModelType, StorageUnitType, RecordType}(model)
+                StorageUnitWrapper{ModelType, StorageUnitType, RecordType}(model)
         end
     end
 end

--- a/src/ColunaBase/ColunaBase.jl
+++ b/src/ColunaBase/ColunaBase.jl
@@ -29,7 +29,7 @@ export TerminationStatus, SolutionStatus, OPTIMAL, INFEASIBLE, TIME_LIMIT,
 
 # Storages (TODO : clean)
 export RecordsVector, UnitTypePair, StorageDict, AbstractStorageUnit, AbstractRecord,
-    UnitsUsageDict, UnitAccessMode, READ_AND_WRITE, READ_ONLY, NOT_USED, Storage,
+    UnitsUsageDict, UnitAccessMode, READ_AND_WRITE, READ_ONLY, NOT_USED, StorageUnitWrapper,
     add_unit_pair_usage!, store_record!, restore_from_records!, getunit, copy_records,
     restore_from_record!, remove_records!, check_records_participation
 

--- a/src/ColunaBase/storage.jl
+++ b/src/ColunaBase/storage.jl
@@ -58,7 +58,7 @@ is called during storing a unit.
 abstract type AbstractRecord end
 
 """
-    restore_from_record!(model, unit, record_record)
+    restore_from_record!(model, unit, record)
 
 This method should be defined for every triple (model type, unit type, record type)
 used by an algorithm.     
@@ -173,14 +173,14 @@ increaseparticipation!(erw::EmptyRecordWrapper) = nothing
 decreaseparticipation!(erw::EmptyRecordWrapper) = nothing
 
 """
-    Storage
+    StorageUnitWrapper
 
 This container keeps a storage unit and all records which have been 
 stored. It implements storing and restoring records of units in an 
 efficient way. 
 """
 
-mutable struct Storage{M <: AbstractModel,SU <: AbstractStorageUnit,R <: AbstractRecord}
+mutable struct StorageUnitWrapper{M <: AbstractModel,SU <: AbstractStorageUnit,R <: AbstractRecord}
     model::M
     cur_record::RecordWrapper{R}
     maxrecordid::RecordId
@@ -189,20 +189,20 @@ mutable struct Storage{M <: AbstractModel,SU <: AbstractStorageUnit,R <: Abstrac
     recordsdict::Dict{RecordId,RecordWrapper{R}}
 end
 
-getunit(s::Storage) = s.storage_unit # needed by Algorithms
+getunit(s::StorageUnitWrapper) = s.storage_unit # needed by Algorithms
 
-const RecordsVector = Vector{Pair{Storage,RecordId}}
+const RecordsVector = Vector{Pair{StorageUnitWrapper,RecordId}}
 
-const StorageDict = Dict{UnitTypePair,Storage}
+const StorageDict = Dict{UnitTypePair,StorageUnitWrapper}
 
-function Storage{M,SU,R}(model::M) where {M,SU,R}
-    return Storage{M,SU,R}(
+function StorageUnitWrapper{M,SU,R}(model::M) where {M,SU,R}
+    return StorageUnitWrapper{M,SU,R}(
         model, RecordWrapper{R}(1, 0), 1, SU(model), 
         SU => R, Dict{RecordId,RecordWrapper{R}}()
     )
 end    
 
-function Base.show(io::IO, storage::Storage)
+function Base.show(io::IO, storage::StorageUnitWrapper)
     print(io, "unit (")
     print(IOContext(io, :compact => true), storage.model)
     (StorageUnitType, RecordType) = storage.typepair    
@@ -211,7 +211,7 @@ function Base.show(io::IO, storage::Storage)
 end
 
 function setcurrecord!(
-    storage::Storage{M,SU,R}, record::RecordWrapper{R}
+    storage::StorageUnitWrapper{M,SU,R}, record::RecordWrapper{R}
 ) where {M,SU,R} 
     # we delete the current record container from the dictionary if necessary
     if !recordisempty(storage.cur_record) && getparticipation(storage.cur_record) == 0
@@ -224,7 +224,7 @@ function setcurrecord!(
     end
 end
 
-function increaseparticipation!(storage::Storage, recordid::RecordId)
+function increaseparticipation!(storage::StorageUnitWrapper, recordid::RecordId)
     record = storage.cur_record
     if getrecordid(record) == recordid
         increaseparticipation!(record)
@@ -236,7 +236,7 @@ function increaseparticipation!(storage::Storage, recordid::RecordId)
     end
 end
 
-function retrieve_from_recordsdict(storage::Storage, recordid::RecordId)
+function retrieve_from_recordsdict(storage::StorageUnitWrapper, recordid::RecordId)
     if !haskey(storage.recordsdict, recordid)
         error(string("State with id $recordid does not exist for ", storage))
     end
@@ -249,7 +249,7 @@ function retrieve_from_recordsdict(storage::Storage, recordid::RecordId)
 end
 
 function save_to_recordsdict!(
-    storage::Storage{M,SU,R}, record::RecordWrapper{R}
+    storage::StorageUnitWrapper{M,SU,R}, record::RecordWrapper{R}
 ) where {M,SU,R}
     if getparticipation(record) > 0 && recordisempty(record)
         record_content = R(storage.model, storage.storage_unit)
@@ -259,13 +259,13 @@ function save_to_recordsdict!(
     end
 end
 
-function store_record!(storage::Storage)::RecordId 
+function store_record!(storage::StorageUnitWrapper)::RecordId 
     increaseparticipation!(storage.cur_record)
     return getrecordid(storage.cur_record)
 end
 
 function restore_from_record!(
-    storage::Storage{M,SU,R}, recordid::RecordId, mode::UnitAccessMode
+    storage::StorageUnitWrapper{M,SU,R}, recordid::RecordId, mode::UnitAccessMode
 ) where {M,SU,R}
     record = storage.cur_record
     if getrecordid(record) == recordid 
@@ -301,7 +301,7 @@ function restore_from_record!(
     end
 end
 
-function check_records_participation(storage::Storage)
+function check_records_participation(storage::StorageUnitWrapper)
     if getparticipation(storage.cur_record) > 0
         @warn string("Positive participation of record ", storage.cur_record)
     end
@@ -321,7 +321,7 @@ end
 # not used for the moment as it has impact on the code readability
 # we keep this function for a while for the case when `restore_from_records!`
 # happens to be a bottleneck
-# function reserve_for_writing!(storage::Storage{M,SU,R}) where {M,SU,R}
+# function reserve_for_writing!(storage::StorageUnitWrapper{M,SU,R}) where {M,SU,R}
 #     save_to_recordsdict!(storage, storage.cur_record)
 #     storage.cur_record = RecordWrapper{R}(storage.maxrecordid + 1, 0)
 #     setcurrecord!(storage, storage.cur_record)

--- a/src/ColunaBase/storage.jl
+++ b/src/ColunaBase/storage.jl
@@ -9,7 +9,7 @@ of an algorithm or between runs of different algorithms.
 Models are storage units themselves. Each unit is associated with a
 model. Thus a unit adds computed data to a model.  
 
-Records are useful to store states of storage units at some point 
+Records are useful to store records of storage units at some point 
 of the calculation flow so that we can later return to this point and 
 restore the units. For example, the calculation flow may return to
 some saved node in the search tree.
@@ -27,9 +27,9 @@ Every stored record should be removed or restored using functions
 "restore_from_records!(::RecordsVector,::UnitsUsageDict)" 
 and "remove_records!(::RecordsVector)"
 
-After recording current states, if we write to some storage unit, we should restore 
+After recording current records, if we write to some storage unit, we should restore 
 it for writing using "restore_from_records!(...)" 
-After recording current states, if we read from a storage unit, 
+After recording current records, if we read from a storage unit, 
 no particular precautions should be taken.   
 """
 
@@ -58,15 +58,15 @@ is called during storing a unit.
 abstract type AbstractRecord end
 
 """
-    restore_from_record!(model, unit, record_state)
+    restore_from_record!(model, unit, record_record)
 
 This method should be defined for every triple (model type, unit type, record type)
 used by an algorithm.     
 """
-restore_from_record!(model::AbstractModel, unit::AbstractStorageUnit, state::AbstractRecord) =
+restore_from_record!(model::AbstractModel, unit::AbstractStorageUnit, record::AbstractRecord) =
     error(string(
         "restore_from_record! not defined for model type $(typeof(model)), ",
-        "unit type $(typeof(unit)), and record type $(typeof(state))"
+        "unit type $(typeof(unit)), and record type $(typeof(record))"
     ))    
 
 
@@ -120,40 +120,40 @@ end
 """
     RecordWrapper
 
-This container keeps additional record information needed for 
-keeping the number of times the state has been stored. When 
-this number drops to zero, the state can be deleted. 
+It wraps and contains additional information about a record.
+The participation is equal to the number of times the record has been stored.
+When the participation drops to zero, the record can be deleted. 
 """
 
 const RecordId = Int
 
-mutable struct RecordWrapper{SS <: AbstractRecord}
+mutable struct RecordWrapper{R <: AbstractRecord}
     id::RecordId
     participation::Int
-    state::Union{Nothing,SS}
+    record::Union{R,Nothing}
 end
 
-RecordWrapper{SS}(recordid::RecordId, participation::Int) where {SS <: AbstractRecord} =
-    RecordWrapper{SS}(recordid, participation, nothing)
+RecordWrapper{R}(recordid::RecordId, participation::Int) where {R <: AbstractRecord} =
+    RecordWrapper{R}(recordid, participation, nothing)
 
-getrecordid(ssc::RecordWrapper) = ssc.id
-stateisempty(ssc::RecordWrapper) = ssc.state === nothing
-getparticipation(ssc::RecordWrapper) = ssc.participation
-getstate(ssc::RecordWrapper) = ssc.state
-increaseparticipation!(ssc::RecordWrapper) = ssc.participation += 1
-decreaseparticipation!(ssc::RecordWrapper) = ssc.participation -= 1
+getrecordid(rw::RecordWrapper) = rw.id
+recordisempty(rw::RecordWrapper) = rw.record === nothing
+getparticipation(rw::RecordWrapper) = rw.participation
+getrecord(rw::RecordWrapper) = rw.record
+increaseparticipation!(rw::RecordWrapper) = rw.participation += 1
+decreaseparticipation!(rw::RecordWrapper) = rw.participation -= 1
 
-function setstate!(ssc::RecordWrapper{SS}, state_to_set::SS) where {SS <: AbstractRecord}
-    ssc.state = state_to_set
+function setrecord!(rw::RecordWrapper{R}, record_to_set::R) where {R <: AbstractRecord}
+    rw.record = record_to_set
 end
 
-function Base.show(io::IO, recordcont::RecordWrapper{SS}) where {SS <: AbstractRecord}
-    print(io, "state ", remove_until_last_point(string(SS)))
+function Base.show(io::IO, recordcont::RecordWrapper{R}) where {R <: AbstractRecord}
+    print(io, "record ", remove_until_last_point(string(R)))
     print(io, " with id=", getrecordid(recordcont), " part=", getparticipation(recordcont))
-    if getstate(recordcont) === nothing
+    if getrecord(recordcont) === nothing
         print(io, " empty")
     else
-        print(io, " ", getstate(recordcont))
+        print(io, " ", getrecord(recordcont))
     end
 end
 
@@ -166,11 +166,11 @@ const EmptyRecordWrapper = RecordWrapper{EmptyRecord}
 EmptyRecordWrapper(recordid::RecordId, participation::Int) =
     EmptyRecordWrapper(1, 0)
 
-getrecordid(essc::EmptyRecordWrapper) = 1
-stateisempty(essc::EmptyRecordWrapper) = true 
-getparticipation(essc::EmptyRecordWrapper) = 0
-increaseparticipation!(essc::EmptyRecordWrapper) = nothing
-decreaseparticipation!(essc::EmptyRecordWrapper) = nothing
+getrecordid(erw::EmptyRecordWrapper) = 1
+recordisempty(erw::EmptyRecordWrapper) = true 
+getparticipation(erw::EmptyRecordWrapper) = 0
+increaseparticipation!(erw::EmptyRecordWrapper) = nothing
+decreaseparticipation!(erw::EmptyRecordWrapper) = nothing
 
 """
     Storage
@@ -180,23 +180,23 @@ stored. It implements storing and restoring records of units in an
 efficient way. 
 """
 
-mutable struct Storage{M <: AbstractModel,S <: AbstractStorageUnit,SS <: AbstractRecord}
+mutable struct Storage{M <: AbstractModel,S <: AbstractStorageUnit,R <: AbstractRecord}
     model::M
-    currecordcont::RecordWrapper{SS}
+    currecordcont::RecordWrapper{R}
     maxrecordid::RecordId
     storage_unit::S
     typepair::UnitTypePair
-    recordsdict::Dict{RecordId,RecordWrapper{SS}}
+    recordsdict::Dict{RecordId,RecordWrapper{R}}
 end 
 
 const RecordsVector = Vector{Pair{Storage,RecordId}}
 
 const StorageDict = Dict{UnitTypePair,Storage}
 
-function Storage{M,S,SS}(model::M) where {M,S,SS}
-    return Storage{M,S,SS}(
-        model, RecordWrapper{SS}(1, 0), 1, S(model), 
-        S => SS, Dict{RecordId,RecordWrapper{SS}}()
+function Storage{M,S,R}(model::M) where {M,S,R}
+    return Storage{M,S,R}(
+        model, RecordWrapper{R}(1, 0), 1, S(model), 
+        S => R, Dict{RecordId,RecordWrapper{R}}()
     )
 end    
 
@@ -215,14 +215,14 @@ function Base.show(io::IO, storagecont::Storage)
     print(io, ", ", remove_until_last_point(string(RecordType)), ")")        
 end
 
-function setcurstate!(
-    storagecont::Storage{M,S,SS}, recordcont::RecordWrapper{SS}
-) where {M,S,SS} 
-    # we delete the current state container from the dictionary if necessary
+function setcurrecord!(
+    storagecont::Storage{M,S,R}, recordcont::RecordWrapper{R}
+) where {M,S,R} 
+    # we delete the current record container from the dictionary if necessary
     currecordcont = getcurrecordcont(storagecont)
-    if !stateisempty(currecordcont) && getparticipation(currecordcont) == 0
+    if !recordisempty(currecordcont) && getparticipation(currecordcont) == 0
         delete!(getrecordsdict(storagecont), getrecordid(currecordcont))
-        #@logmsg LogLevel(-2) string("Removed state with id ", getrecordid(currecordcont), " for ", storagecont)
+        # @logmsg LogLevel(-2) string("Removed record with id ", getrecordid(currecordcont), " for ", storagecont)
     end
     storagecont.currecordcont = recordcont
     if getmaxrecordid(storagecont) < getrecordid(recordcont) 
@@ -251,18 +251,18 @@ function retrieve_from_recordsdict(storagecont::Storage, recordid::RecordId)
     recordcont = recordsdict[recordid]
     decreaseparticipation!(recordcont)
     if getparticipation(recordcont) < 0
-        error(string("Participation is below zero for state with id $recordid of ", storagecont))
+        error(string("Participation is below zero for record with id $recordid of ", storagecont))
     end
     return recordcont
 end
 
 function save_to_recordsdict!(
-    storagecont::Storage{M,S,SS}, recordcont::RecordWrapper{SS}
-) where {M,S,SS}
-    if getparticipation(recordcont) > 0 && stateisempty(recordcont)
-        state = SS(getmodel(storagecont), getunit(storagecont))
-        #@logmsg LogLevel(-2) string("Created state with id ", getrecordid(recordcont), " for ", storagecont)
-        setstate!(recordcont, state)
+    storagecont::Storage{M,S,R}, recordcont::RecordWrapper{R}
+) where {M,S,R}
+    if getparticipation(recordcont) > 0 && recordisempty(recordcont)
+        record = R(getmodel(storagecont), getunit(storagecont))
+        # @logmsg LogLevel(-2) string("Created record with id ", getrecordid(recordcont), " for ", storagecont)
+        setrecord!(recordcont, record)
         recordsdict = getrecordsdict(storagecont)
         recordsdict[getrecordid(recordcont)] = recordcont
     end
@@ -275,51 +275,51 @@ function store_record!(storagecont::Storage)::RecordId
 end
 
 function restore_from_record!(
-    storagecont::Storage{M,S,SS}, recordid::RecordId, mode::UnitAccessMode
-) where {M,S,SS}
+    storagecont::Storage{M,S,R}, recordid::RecordId, mode::UnitAccessMode
+) where {M,S,R}
     recordcont = getcurrecordcont(storagecont)
     if getrecordid(recordcont) == recordid 
         decreaseparticipation!(recordcont)
         if getparticipation(recordcont) < 0
-            error(string("Participation is below zero for state with id $recordid of ", getnicename(storagecont)))
+            error(string("Participation is below zero for record with id $recordid of ", getnicename(storagecont)))
         end
         if mode == READ_AND_WRITE 
             save_to_recordsdict!(storagecont, recordcont)
-            recordcont = RecordWrapper{SS}(getmaxrecordid(storagecont) + 1, 0)
-            setcurstate!(storagecont, recordcont)
+            recordcont = RecordWrapper{R}(getmaxrecordid(storagecont) + 1, 0)
+            setcurrecord!(storagecont, recordcont)
         end
         return
     elseif mode != NOT_USED
-        # we save current state to dictionary if necessary
+        # we save current record to dictionary if necessary
         save_to_recordsdict!(storagecont, recordcont)
     end
     
     recordcont = retrieve_from_recordsdict(storagecont, recordid)
     
     if mode == NOT_USED
-        if !stateisempty(recordcont) && getparticipation(recordcont) == 0
+        if !recordisempty(recordcont) && getparticipation(recordcont) == 0
             delete!(getrecordsdict(storagecont), getrecordid(recordcont))
-            #@logmsg LogLevel(-2) string("Removed state with id ", getrecordid(recordcont), " for ", storagecont)
+            # @logmsg LogLevel(-2) string("Removed record with id ", getrecordid(recordcont), " for ", storagecont)
         end
     else 
-        restore_from_record!(getmodel(storagecont), getunit(storagecont), getstate(recordcont))
-        #@logmsg LogLevel(-2) string("Restored state with id ", getrecordid(recordcont), " for ", storagecont)
+        restore_from_record!(getmodel(storagecont), getunit(storagecont), getrecord(recordcont))
+        # @logmsg LogLevel(-2) string("Restored record with id ", getrecordid(recordcont), " for ", storagecont)
         if mode == READ_AND_WRITE 
-            recordcont = RecordWrapper{SS}(getmaxrecordid(storagecont) + 1, 0)
+            recordcont = RecordWrapper{R}(getmaxrecordid(storagecont) + 1, 0)
         end 
-        setcurstate!(storagecont, recordcont)
+        setcurrecord!(storagecont, recordcont)
     end
 end
 
 function check_records_participation(storagecont::Storage)
     currecordcont = getcurrecordcont(storagecont)
     if getparticipation(currecordcont) > 0
-        @warn string("Positive participation of state ", currecordcont)
+        @warn string("Positive participation of record ", currecordcont)
     end
     recordsdict = getrecordsdict(storagecont)
     for (recordid, recordcont) in recordsdict
         if getparticipation(recordcont) > 0
-            @warn string("Positive participation of state ", recordcont)
+            @warn string("Positive participation of record ", recordcont)
         end
     end
 end
@@ -333,11 +333,11 @@ end
 # not used for the moment as it has impact on the code readability
 # we keep this function for a while for the case when `restore_from_records!`
 # happens to be a bottleneck
-# function reserve_for_writing!(storagecont::Storage{M,S,SS}) where {M,S,SS}
+# function reserve_for_writing!(storagecont::Storage{M,S,R}) where {M,S,R}
 #     recordcont = getcurrecordcont(storagecont)
 #     save_to_recordsdict!(storagecont, recordcont)
-#     recordcont = RecordWrapper{SS}(getmaxrecordid(storagecont) + 1, 0)
-#     setcurstate!(storagecont, recordcont)
+#     recordcont = RecordWrapper{R}(getmaxrecordid(storagecont) + 1, 0)
+#     setcurrecord!(storagecont, recordcont)
 # end
 
 function restore_from_records!(units_to_restore::UnitsUsageDict, records::RecordsVector)
@@ -378,7 +378,7 @@ end
 """
     IMPORTANT!
 
-    Every stored or copied state should be either restored or removed so that it's 
+    Every stored or copied record should be either restored or removed so that it's 
     participation is correctly computed and memory correctly controlled
 """
 


### PR DESCRIPTION
I removed getters of `Storage` (except `getunit` for the moment) because methods were only used in `storages.jl` and so seem to be private.

task for #330 
 