### PR TITLE
Support of variable branching priorities in the branching algorithm

### DIFF
--- a/docs/src/dev/formulation.md
+++ b/docs/src/dev/formulation.md
@@ -77,6 +77,7 @@ activate!
 deactivate!
 isexplicit
 getname
+getbranchingpriority
 ```
 
 ```@meta

--- a/src/Algorithm/branching/branchingalgo.jl
+++ b/src/Algorithm/branching/branchingalgo.jl
@@ -253,7 +253,7 @@ function run!(algo::StrongBranching, env::Env, data::ReformData, input::DivideIn
         # generate candidates
         output = run!(rule, env, data, BranchingRuleInput(
             original_solution, true, nb_candidates_needed, algo.selection_criterion, 
-            local_id, algo.int_tol
+            local_id, algo.int_tol, min_priority
         ))
         nb_candidates_found += length(output.groups)
         append!(kept_branch_groups, output.groups)
@@ -262,7 +262,7 @@ function run!(algo::StrongBranching, env::Env, data::ReformData, input::DivideIn
         if projection_is_possible(master) && extended_solution !== nothing
             output = run!(rule, env, data, BranchingRuleInput(
                 extended_solution, false, nb_candidates_needed, algo.selection_criterion, 
-                local_id, algo.int_tol
+                local_id, algo.int_tol, min_priority
             ))   
             nb_candidates_found += length(output.groups)
             append!(kept_branch_groups, output.groups)

--- a/src/Algorithm/branching/branchingrule.jl
+++ b/src/Algorithm/branching/branchingrule.jl
@@ -17,6 +17,7 @@ struct BranchingRuleInput <: AbstractInput
     criterion::SelectionCriterion
     local_id::Int64
     int_tol::Float64
+    minimum_priority::Float64
 end
 
 """

--- a/src/Algorithm/branching/varbranching.jl
+++ b/src/Algorithm/branching/varbranching.jl
@@ -87,6 +87,7 @@ function run!(
     for (var_id, val) in input.solution
         # Do not consider continuous variables as branching candidates
         getperenkind(master, var_id) == Continuous && continue
+        getbranchingpriority(master, var_id) < input.minimum_priority && continue
         if !isinteger(val, input.int_tol)
             #description string is just the variable name
             candidate = VarBranchingCandidate(getname(master, var_id), var_id)

--- a/src/Algorithm/treesearch.jl
+++ b/src/Algorithm/treesearch.jl
@@ -243,11 +243,14 @@ function run_conquer_algorithm!(
 
     algo.print_node_info && print_node_info_before_conquer(tsdata, env, node)
 
-    node.conquerwasrun && return
-
     treestate = getoptstate(tsdata)
     nodestate = getoptstate(node)
     update_ip_primal!(nodestate, treestate, tsdata.exploitsprimalsolutions)
+
+    # in the case the conquer was already run (in strong branching),
+    # we still need to update the node IP primal bound before exiting 
+    # (to possibly avoid branching)
+    node.conquerwasrun && return
 
     apply_conquer_alg_to_node!(
         node, algo.conqueralg, env, rfdata, tsdata.conquer_units_to_restore, 

--- a/src/MOIwrapper.jl
+++ b/src/MOIwrapper.jl
@@ -402,7 +402,7 @@ function MOI.set(
     model::Coluna.Optimizer, ::BD.VarBranchingPriority, varid::MOI.VariableIndex, branching_priority::Int
 )
     var = model.vars[varid]
-    var.branching_priority = branching_priority
+    var.branching_priority = Float64(branching_priority)
     return
 end
 

--- a/src/MathProg/MathProg.jl
+++ b/src/MathProg/MathProg.jl
@@ -97,7 +97,7 @@ export Variable, Constraint, VarId, ConstrId, VarMembership, ConstrMembership,
     getperenub, getcurub, setcurub!, getperenrhs, getcurrhs, setcurrhs!, getperensense,
     getcursense, setcursense!, getperenkind, getcurkind, setcurkind!, getperenincval,
     getcurincval, setcurincval!, isperenactive, iscuractive, activate!, deactivate!,
-    isexplicit, getname, reset!, getreducedcost
+    isexplicit, getname, getbranchingpriority, reset!, getreducedcost
 
 # Types & methods related to solutions & bounds
 export PrimalBound, DualBound, PrimalSolution, DualSolution, ObjValues,

--- a/src/MathProg/clone.jl
+++ b/src/MathProg/clone.jl
@@ -12,13 +12,14 @@ function clonevar!(
     inc_val::Float64 = getperenincval(originform, var),
     is_active::Bool = isperenactive(originform, var),
     is_explicit::Bool = isexplicit(originform, var),
+    branching_priority::Float64 = getbranchingpriority(originform, var),
     members::Union{ConstrMembership,Nothing} = nothing
 )
     return setvar!(
         destform, name, duty; 
         cost = cost, lb = lb, ub = ub, kind = kind,
         inc_val = inc_val, is_active = is_active, is_explicit = is_explicit, 
-        members = members,
+        branching_priority = branching_priority, members = members, 
         id = Id{Variable}(duty, getid(var), getuid(assignedform))
     )
 end

--- a/src/MathProg/formulation.jl
+++ b/src/MathProg/formulation.jl
@@ -154,7 +154,7 @@ function setvar!(
     moi_index::MoiVarIndex = MoiVarIndex(),
     members::Union{ConstrMembership,Nothing} = nothing,
     id = generatevarid(duty, form),
-    branching_priority::Int = 1
+    branching_priority::Float64 = 1.0
 )
     if kind == Binary
         lb = (lb < 0.0) ? 0.0 : lb

--- a/src/MathProg/varconstr.jl
+++ b/src/MathProg/varconstr.jl
@@ -438,6 +438,16 @@ getname(form::Formulation, var::Variable) = var.name
 getname(form::Formulation, constrid::ConstrId) = getconstr(form, constrid).name
 getname(form::Formulation, constr::Constraint) = constr.name
 
+## branching_priority
+"""
+    getbranchingpriority(formulation, var)
+    getbranchingpriority(formulation, varid)
+
+Return the branching priority of a variable
+"""
+getbranchingpriority(form::Formulation, varid::VarId) = getvar(form, varid).branching_priority
+getbranchingpriority(form::Formulation, var::Variable) = var.branching_priority
+
 # Reset
 """
     reset!(form, var)

--- a/src/MathProg/variable.jl
+++ b/src/MathProg/variable.jl
@@ -76,7 +76,7 @@ mutable struct Variable <: AbstractVarConstr
     name::String
     perendata::VarData
     curdata::VarData
-    branching_priority::Int
+    branching_priority::Float64
     moirecord::MoiVarRecord
 end
 
@@ -85,7 +85,7 @@ const VarId = Id{Variable}
 getid(var::Variable) = var.id
 
 function Variable(
-    id::VarId, name::String; var_data = VarData(), branching_priority::Int = 1,
+    id::VarId, name::String; var_data = VarData(), branching_priority::Float64 = 1.0,
     moi_index::MoiVarIndex = MoiVarIndex()
 )
     return Variable(


### PR DESCRIPTION
This functionality works, but we also need to change the type of branching priorities in `BlockDecomposition` from `Int` to `Float`.  

The idea of fractional branching priorities to have both "soft" and "hard" branching priorities in strong branching:
- If the number of branching candidates with priority 4.0 is less than the maximum number, no branching candidates with priority 3.0 will be considered. 
- If the number of branching candidates with priority 3.5 is less than the maximum number, then some branching candidates with priority 3.0 will be considered (to bring the total number to the maximum). 
- If the number of branching candidates with priority 3.5 is not less than the maximum number, then no branching candidates with priority 3.0 will be considered. 