### PR TITLE
Refactoring `ObjValues` & `OptimizationState`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,8 @@ jobs:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
       - run: julia --project=@. -e 'using Pkg; Pkg.add(PackageSpec(url="https://github.com/atoptima/ColunaDemos.jl.git"));'
+      - run: julia --project=@. -e 'using Pkg; Pkg.add(PackageSpec(url="https://github.com/rafaelmartinelli/KnapsackLib.jl"));'
+      - run: julia --project=@. -e 'using Pkg; Pkg.add("BlockDecomposition#master"));'
       - uses: actions/cache@v1
         env:
           cache-name: cache-artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,8 @@ jobs:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
       - run: julia --project=@. -e 'using Pkg; Pkg.add(PackageSpec(url="https://github.com/atoptima/ColunaDemos.jl.git"));'
-      - run: julia --project=@. -e 'using Pkg; Pkg.add(PackageSpec(url="https://github.com/rafaelmartinelli/KnapsackLib.jl"));'
-      - run: julia --project=@. -e 'using Pkg; Pkg.add("BlockDecomposition#master"));'
+      - run: julia --project=@. -e 'using Pkg; Pkg.add(PackageSpec(url="https://github.com/rafaelmartinelli/KnapsackLib.jl.git"));'
+      - run: julia --project=@. -e 'using Pkg; Pkg.add(PackageSpec(url="https://github.com/atoptima/BlockDecomposition.jl.git"));'
       - uses: actions/cache@v1
         env:
           cache-name: cache-artifacts

--- a/src/Algorithm/Algorithm.jl
+++ b/src/Algorithm/Algorithm.jl
@@ -60,12 +60,12 @@ include("treesearch.jl")
 
 # Utilities
 export getterminationstatus, setterminationstatus!,
-    nb_ip_primal_sols, nb_lp_primal_sols, nb_lp_dual_sols,
     get_ip_primal_sols, get_lp_primal_sols, get_lp_dual_sols, get_best_ip_primal_sol,
     get_best_lp_primal_sol, get_best_lp_dual_sol, update_ip_primal_sol!,
     update_lp_primal_sol!, update_lp_dual_sol!, add_ip_primal_sol!, add_lp_primal_sol!,
     add_lp_dual_sol!, set_ip_primal_sol!, set_lp_primal_sol!, set_lp_dual_sol!,
-    get_ip_dual_bound, set_ip_dual_bound!, update_all_ip_primal_solutions!, getreform,
+    empty_ip_primal_sols!, empty_lp_primal_sols!, empty_lp_dual_sols!,
+    get_ip_dual_bound, set_ip_dual_bound!, getreform,
     getoptstate, run!, isinfeasible
     
 # Algorithm's types

--- a/src/Algorithm/Algorithm.jl
+++ b/src/Algorithm/Algorithm.jl
@@ -65,7 +65,7 @@ export getterminationstatus, setterminationstatus!,
     
 # Algorithm's types
 export AbstractOptimizationAlgorithm, TreeSearchAlgorithm, ColCutGenConquer, ColumnGeneration,
-       BendersConquer, BendersCutGeneration, SolveIpForm, RestrictedMasterHeuristic,
+       BendersConquer, BendersCutGeneration, SolveIpForm, RestrictedMasterIPHeuristic,
        SolveLpForm, ExactBranchingPhase, OnlyRestrictedMasterBranchingPhase, PreprocessAlgorithm, 
        OptimizationInput, OptimizationOutput, OptimizationState, EmptyInput
 

--- a/src/Algorithm/Algorithm.jl
+++ b/src/Algorithm/Algorithm.jl
@@ -14,13 +14,6 @@ const MOI = MathOptInterface
 
 import Base: push!
 
-# Import to extend methods to OptimizationState
-import ..MathProg:
-    get_ip_primal_bound, get_ip_dual_bound,
-    get_lp_primal_bound, get_lp_dual_bound, update_ip_primal_bound!, update_ip_dual_bound!,
-    update_lp_primal_bound!, update_lp_dual_bound!, set_ip_primal_bound!,
-    set_ip_dual_bound!, set_lp_primal_bound!, set_lp_dual_bound!, ip_gap, lp_gap, ip_gap_closed, lp_gap_closed
-
 # Utilities to build algorithms
 include("utilities/optimizationstate.jl")
 
@@ -62,10 +55,12 @@ include("treesearch.jl")
 export getterminationstatus, setterminationstatus!,
     get_ip_primal_sols, get_lp_primal_sols, get_lp_dual_sols, get_best_ip_primal_sol,
     get_best_lp_primal_sol, get_best_lp_dual_sol, update_ip_primal_sol!,
-    update_lp_primal_sol!, update_lp_dual_sol!, add_ip_primal_sol!, add_lp_primal_sol!,
-    add_lp_dual_sol!, set_ip_primal_sol!, set_lp_primal_sol!, set_lp_dual_sol!,
+    update_lp_primal_sol!, update_lp_dual_sol!, add_ip_primal_sol!, add_ip_primal_sols!,
+    add_lp_primal_sol!, add_lp_dual_sol!, set_ip_primal_sol!, set_lp_primal_sol!, set_lp_dual_sol!,
     empty_ip_primal_sols!, empty_lp_primal_sols!, empty_lp_dual_sols!,
-    get_ip_dual_bound, set_ip_dual_bound!, getreform,
+    get_ip_primal_bound, get_lp_primal_bound, get_lp_dual_bound, get_ip_dual_bound, 
+    set_ip_primal_bound!, set_lp_primal_bound!, set_lp_dual_bound!, set_ip_dual_bound!,
+    update_ip_primal_bound!, update_lp_primal_bound!, update_lp_dual_bound!, update_ip_dual_bound!,
     getoptstate, run!, isinfeasible
     
 # Algorithm's types

--- a/src/Algorithm/benders.jl
+++ b/src/Algorithm/benders.jl
@@ -42,8 +42,9 @@ end
 
 function BendersCutGenRuntimeData(form::Reformulation, init_optstate::OptimizationState)
     optstate = OptimizationState(getmaster(form))
-    if nb_ip_primal_sols(init_optstate) > 0
-        add_ip_primal_sol!(optstate, get_best_ip_primal_sol(init_optstate))
+    best_ip_primal_sol = get_best_ip_primal_sol(init_optstate)
+    if best_ip_primal_sol !== nothing
+        add_ip_primal_sol!(optstate, best_ip_primal_sol)
     end
     return BendersCutGenRuntimeData(optstate, Dict{FormId, FormulationPhase}(), Dict{FormId, Bool}())#0.0, true)
 end

--- a/src/Algorithm/branching/branchingalgo.jl
+++ b/src/Algorithm/branching/branchingalgo.jl
@@ -148,13 +148,19 @@ function perform_strong_branching_with_phases!(
                     @printf "), value = %6.2f\n" getvalue(get_lp_primal_bound(getoptstate(node)))
                 end
 
-                update_ip_primal!(getoptstate(node), sbstate, exploitsprimalsolutions)
+                nodestate = getoptstate(node)
+
+                update_ip_primal_bound!(nodestate, get_ip_primal_bound(sbstate))
+                best_ip_primal_sol = get_best_ip_primal_sol(sbstate)
+                if exploitsprimalsolutions && best_ip_primal_sol !== nothing
+                    set_ip_primal_sol!(nodestate, best_ip_primal_sol)
+                end                
 
                 apply_conquer_alg_to_node!(
                     node, current_phase.conquer_algo, env, reform, conquer_units_to_restore
                 )        
 
-                add_ip_primal_sols!(sbstate, get_ip_primal_sols(getoptstate(node))...)
+                add_ip_primal_sols!(sbstate, get_ip_primal_sols(nodestate)...)
                     
                 if to_be_pruned(node) 
                     if isverbose(current_phase.conquer_algo)

--- a/src/Algorithm/branching/branchingalgo.jl
+++ b/src/Algorithm/branching/branchingalgo.jl
@@ -154,7 +154,7 @@ function perform_strong_branching_with_phases!(
                     node, current_phase.conquer_algo, env, reform, conquer_units_to_restore
                 )        
 
-                update_all_ip_primal_solutions!(sbstate, getoptstate(node))
+                add_ip_primal_sols!(sbstate, get_ip_primal_sols(getoptstate(node))...)
                     
                 if to_be_pruned(node) 
                     if isverbose(current_phase.conquer_algo)
@@ -209,10 +209,9 @@ function run!(algo::StrongBranching, env::Env, reform::Reformulation, input::Div
     # we obtain the original and extended solutions
     master = getmaster(reform)
     original_solution = nothing
-    extended_solution = nothing
-    if nb_lp_primal_sols(optstate) > 0
+    extended_solution = get_best_lp_primal_sol(optstate)
+    if extended_solution !== nothing
         if projection_is_possible(master)
-            extended_solution = get_best_lp_primal_sol(optstate)
             original_solution = proj_cols_on_rep(extended_solution, master)
         else
             original_solution = get_best_lp_primal_sol(optstate)

--- a/src/Algorithm/branching/branchinggroup.jl
+++ b/src/Algorithm/branching/branchinggroup.jl
@@ -59,10 +59,9 @@ function regenerate_children!(group::BranchingGroup, parent::Node)
 end
 
 function product_score(group::BranchingGroup, parent_optstate::OptimizationState)
-    parent_inc = getincumbents(parent_optstate)
     # TO DO : we need to mesure the gap to the cut-off value
-    parent_lp_dual_bound = get_lp_dual_bound(parent_inc)
-    parent_delta = diff(get_ip_primal_bound(parent_inc), parent_lp_dual_bound)
+    parent_lp_dual_bound = get_lp_dual_bound(parent_optstate)
+    parent_delta = diff(get_ip_primal_bound(parent_optstate), parent_lp_dual_bound)
 
     all_branches_above_delta = true
     deltas = zeros(Float64, length(group.children))
@@ -126,11 +125,9 @@ function tree_depth_score(group::BranchingGroup, parent_optstate::OptimizationSt
         return 0.0
     end
 
-    parent_inc = getincumbents(parent_optstate)
-    
     # TO DO : we need to mesure the gap to the cut-off value
-    parent_lp_dual_bound = get_lp_dual_bound(parent_inc)
-    parent_delta = diff(get_ip_primal_bound(parent_inc), parent_lp_dual_bound)
+    parent_lp_dual_bound = get_lp_dual_bound(parent_optstate)
+    parent_delta = diff(get_ip_primal_bound(parent_optstate), parent_lp_dual_bound)
 
     deltas = zeros(Float64, length(group.children))
     nb_zero_deltas = 0

--- a/src/Algorithm/conquer.jl
+++ b/src/Algorithm/conquer.jl
@@ -54,7 +54,7 @@ function apply_conquer_alg_to_node!(
         @logmsg LogLevel(-1) string("Tree IP PB: ", get_ip_primal_bound(nodestate))
     end
     if ip_gap_closed(nodestate, rtol = opt_rtol, atol = opt_atol)
-        @info "IP Gap is closed: $(ip_gap(getincumbents(nodestate))). Abort treatment."
+        @info "IP Gap is closed: $(ip_gap(nodestate)). Abort treatment."
     else
         isverbose(algo) && @logmsg LogLevel(-1) string("IP Gap is positive. Need to treat node.")
 

--- a/src/Algorithm/conquer.jl
+++ b/src/Algorithm/conquer.jl
@@ -69,6 +69,13 @@ end
 #                      ParameterisedHeuristic
 ####################################################################
 
+"""
+    Coluna.Algorithm.RestrictedMasterHeuristic()
+
+This algorithm enforces integrality of column variables in the master formulation and then solves the master formulation with its optimizer.
+"""
+RestrictedMasterIPHeuristic() = SolveIpForm(moi_params = MoiOptimize(get_dual_bound = false))
+
 struct ParameterisedHeuristic
     algorithm::AbstractOptimizationAlgorithm
     root_priority::Float64
@@ -78,14 +85,9 @@ struct ParameterisedHeuristic
     name::String
 end
 
-"""
-    Coluna.Algorithm.RestrictedMasterHeuristic()
-
-This algorithm enforces integrality of column variables in the master formulation and then solves the master formulation with its optimizer.
-"""
-RestrictedMasterHeuristic() = 
+ParamRestrictedMasterHeuristic() = 
     ParameterisedHeuristic(
-        SolveIpForm(moi_params = MoiOptimize(get_dual_bound = false)), 
+        RestrictedMasterIPHeuristic(), 
         1.0, 1.0, 1, 1000, "Restricted Master IP"
     )
 
@@ -124,7 +126,7 @@ end
 """
     Coluna.Algorithm.ColCutGenConquer(
         stages::Vector{ColumnGeneration} = [ColumnGeneration()]
-        primal_heuristics::Vector{ParameterisedHeuristic} = [RestrictedMasterHeuristic()]
+        primal_heuristics::Vector{ParameterisedHeuristic} = [ParamRestrictedMasterHeuristic()]
         preprocess = PreprocessAlgorithm()
         cutgen = CutCallbacks()
         run_preprocessing::Bool = false
@@ -139,7 +141,7 @@ several primal heuristics to more efficiently find feasible solutions.
 """
 @with_kw struct ColCutGenConquer <: AbstractConquerAlgorithm 
     stages::Vector{ColumnGeneration} = [ColumnGeneration()]
-    primal_heuristics::Vector{ParameterisedHeuristic} = [RestrictedMasterHeuristic()]
+    primal_heuristics::Vector{ParameterisedHeuristic} = [ParamRestrictedMasterHeuristic()]
     preprocess = PreprocessAlgorithm()
     cutgen = CutCallbacks()
     max_nb_cut_rounds::Int = 3 # TODO : tailing-off ?

--- a/src/Algorithm/treesearch.jl
+++ b/src/Algorithm/treesearch.jl
@@ -244,7 +244,12 @@ function run_conquer_algorithm!(
 
     treestate = getoptstate(tsdata)
     nodestate = getoptstate(node)
-    update_ip_primal!(nodestate, treestate, tsdata.exploitsprimalsolutions)
+
+    update_ip_primal_bound!(nodestate, get_ip_primal_bound(treestate))
+    best_ip_primal_sol = get_best_ip_primal_sol(nodestate)
+    if tsdata.exploitsprimalsolutions && best_ip_primal_sol !== nothing
+        set_ip_primal_sol!(treestate, best_ip_primal_sol)
+    end
 
     # in the case the conquer was already run (in strong branching),
     # we still need to update the node IP primal bound before exiting 

--- a/src/Algorithm/utilities/optimizationstate.jl
+++ b/src/Algorithm/utilities/optimizationstate.jl
@@ -137,60 +137,109 @@ end
 getterminationstatus(state::OptimizationState) = state.termination_status
 setterminationstatus!(state::OptimizationState, status::TerminationStatus) = state.termination_status = status
 
-getincumbents(state::OptimizationState) = state.incumbents
 
-get_ip_primal_bound(state::OptimizationState) = get_ip_primal_bound(state.incumbents)
-get_lp_primal_bound(state::OptimizationState) = get_lp_primal_bound(state.incumbents)
-get_ip_dual_bound(state::OptimizationState) = get_ip_dual_bound(state.incumbents)
-get_lp_dual_bound(state::OptimizationState) = get_lp_dual_bound(state.incumbents)
+"Return the best IP primal bound."
+get_ip_primal_bound(state::OptimizationState) = state.incumbents.ip_primal_bound
 
-update_ip_primal_bound!(state::OptimizationState, val) = update_ip_primal_bound!(state.incumbents, val)
-update_ip_dual_bound!(state::OptimizationState, val) = update_ip_dual_bound!(state.incumbents, val)
-update_lp_primal_bound!(state::OptimizationState, val) = update_lp_primal_bound!(state.incumbents, val)
-update_lp_dual_bound!(state::OptimizationState, val) = update_lp_dual_bound!(state.incumbents, val)
+"Return the best LP primal bound."
+get_lp_primal_bound(state::OptimizationState) = state.incumbents.lp_primal_bound
 
-set_ip_primal_bound!(state::OptimizationState, val) = set_ip_primal_bound!(state.incumbents, val)
-set_lp_primal_bound!(state::OptimizationState, val) = set_lp_primal_bound!(state.incumbents, val)
-set_ip_dual_bound!(state::OptimizationState, val) = set_ip_dual_bound!(state.incumbents, val)
-set_lp_dual_bound!(state::OptimizationState, val) = set_lp_dual_bound!(state.incumbents, val)
+"Return the best IP dual bound."
+get_ip_dual_bound(state::OptimizationState) = state.incumbents.ip_dual_bound
 
-ip_gap(state::OptimizationState) = ip_gap(state.incumbents)
-lp_gap(state::OptimizationState) = lp_gap(state.incumbents)
+"Return the best LP dual bound."
+get_lp_dual_bound(state::OptimizationState) = state.incumbents.lp_dual_bound
 
-ip_gap_closed(state::OptimizationState; kw...) = ip_gap_closed(state.incumbents; kw...)
-lp_gap_closed(state::OptimizationState; kw...) = lp_gap_closed(state.incumbents; kw...)
+"""
+Update the primal bound of the mixed-integer program if the new one is better
+than the current one according to the objective sense.
+"""
+update_ip_primal_bound!(state::OptimizationState, bound) = MathProg._update_ip_primal_bound!(state.incumbents, bound)
 
+"""
+Update the dual bound of the mixed-integer program if the new one is better than
+the current one according to the objective sense.
+"""
+update_ip_dual_bound!(state::OptimizationState, bound) = MathProg._update_ip_dual_bound!(state.incumbents, bound)
+
+"""
+Update the primal bound of the linear program if the new one is better than the
+current one according to the objective sense.
+"""
+update_lp_primal_bound!(state::OptimizationState, bound) = MathProg._update_lp_primal_bound!(state.incumbents, bound)
+
+"""
+Update the dual bound of the linear program if the new one is better than the 
+current one according to the objective sense.
+"""
+update_lp_dual_bound!(state::OptimizationState, bound) = MathProg._update_lp_dual_bound!(state.incumbents, bound)
+
+"Set the best IP primal bound."
+set_ip_primal_bound!(state::OptimizationState, bound) = state.incumbents.ip_primal_bound = bound
+
+"Set the best LP primal bound."
+set_lp_primal_bound!(state::OptimizationState, bound) = state.incumbents.lp_primal_bound = bound
+
+"Set the best IP dual bound."
+set_ip_dual_bound!(state::OptimizationState, bound) = state.incumbents.ip_dual_bound = bound
+
+"Set the best LP dual bound."
+set_lp_dual_bound!(state::OptimizationState, bound) = state.incumbents.lp_dual_bound = bound
+
+"""
+Return the gap between the best primal and dual bounds of the integer program.
+Should not be used to check convergence
+"""
+ip_gap(state::OptimizationState) = MathProg._ip_gap(state.incumbents)
+
+"Return the gap between the best primal and dual bounds of the linear program."
+lp_gap(state::OptimizationState) = MathProg._lp_gap(state.incumbents)
+
+"""
+    ip_gap_closed(optstate; atol = Coluna.DEF_OPTIMALITY_ATOL, rtol = Coluna.DEF_OPTIMALITY_RTOL)
+
+Return true if the gap between the best primal and dual bounds of the integer program is closed
+given optimality tolerances.
+"""
+ip_gap_closed(state::OptimizationState; kw...) = MathProg._ip_gap_closed(state.incumbents; kw...)
+
+"""
+    lp_gap_closed(optstate; atol = Coluna.DEF_OPTIMALITY_ATOL, rtol = Coluna.DEF_OPTIMALITY_RTOL)
+
+Return true if the gap between the best primal and dual bounds of the linear program is closed 
+given optimality tolerances.
+"""
+lp_gap_closed(state::OptimizationState; kw...) = MathProg._lp_gap_closed(state.incumbents; kw...)
+
+"Return all IP primal solutions."
 get_ip_primal_sols(state::OptimizationState) = state.ip_primal_sols
 
+
+"Return the best IP primal solution if it exists; `nothing` otherwise."
 function get_best_ip_primal_sol(state::OptimizationState)
     length(state.ip_primal_sols) == 0 && return nothing
     return state.ip_primal_sols[1]
 end
 
+"Return all LP primal solutions."
 get_lp_primal_sols(state::OptimizationState) = state.lp_primal_sols
 
+"Return the best LP primal solution if it exists; `nothing` otherwise."
 function get_best_lp_primal_sol(state::OptimizationState)
     length(state.lp_primal_sols) == 0 && return nothing
     return state.lp_primal_sols[1]
 end
 
+"Return all LP dual solutions."
 get_lp_dual_sols(state::OptimizationState) = state.lp_dual_sols
 
+"Return the best LP dual solution if it exists; `nothing` otherwise."
 function get_best_lp_dual_sol(state::OptimizationState)
     length(state.lp_dual_sols) == 0 && return nothing
     return state.lp_dual_sols[1]
 end
 
-function update_ip_primal!(
-    dest_state::OptimizationState, orig_state::OptimizationState, set_solution::Bool
-)
-    update_ip_primal_bound!(dest_state, get_ip_primal_bound(orig_state))
-    best_ip_primal_sol = get_best_ip_primal_sol(orig_state)
-    if set_solution && best_ip_primal_sol !== nothing
-        set_ip_primal_sol!(dest_state, best_ip_primal_sol)
-    end
-end
-
+# TODO : refactoring ?
 function update!(dest_state::OptimizationState, orig_state::OptimizationState)
     setterminationstatus!(dest_state, getterminationstatus(orig_state))
     add_ip_primal_sols!(dest_state, get_ip_primal_sols(orig_state)...)
@@ -220,7 +269,7 @@ Similar methods :
 function update_ip_primal_sol!(state::OptimizationState{F, S}, sol::PrimalSolution{F}) where {F, S}
     state.max_length_ip_primal_sols == 0 && return
     b = PrimalBound{S}(getvalue(sol))
-    if update_ip_primal_bound!(state.incumbents, b)
+    if update_ip_primal_bound!(state, b)
         state.insert_function_ip_primal_sols(state.ip_primal_sols, state.max_length_ip_primal_sols, sol)
     end
     return
@@ -243,7 +292,7 @@ function add_ip_primal_sol!(state::OptimizationState{F, S}, sol::PrimalSolution{
     state.max_length_ip_primal_sols == 0 && return
     state.insert_function_ip_primal_sols(state.ip_primal_sols, state.max_length_ip_primal_sols, sol)
     b = PrimalBound{S}(getvalue(sol))
-    update_ip_primal_bound!(state.incumbents, b)
+    update_ip_primal_bound!(state, b)
     return
 end
 
@@ -287,7 +336,7 @@ empty_ip_primal_sols!(state::OptimizationState) = empty!(state.ip_primal_sols)
 function update_lp_primal_sol!(state::OptimizationState{F, S}, sol::PrimalSolution{F}) where {F, S}
     state.max_length_lp_primal_sols == 0 && return
     b = PrimalBound{S}(getvalue(sol))
-    if update_lp_primal_bound!(state.incumbents, b)
+    if update_lp_primal_bound!(state, b)
         state.insert_function_lp_primal_sols(state.lp_primal_sols, state.max_length_lp_primal_sols, sol)
     end
     return
@@ -298,7 +347,7 @@ function add_lp_primal_sol!(state::OptimizationState{F, S}, sol::PrimalSolution{
     state.max_length_lp_primal_sols == 0 && return
     state.insert_function_lp_primal_sols(state.lp_primal_sols, state.max_length_lp_primal_sols, sol)
     b = PrimalBound{S}(getvalue(sol))
-    update_lp_primal_bound!(state.incumbents, b)
+    update_lp_primal_bound!(state, b)
     return
 end
 
@@ -316,7 +365,7 @@ empty_lp_primal_sols!(state::OptimizationState) = empty!(state.lp_primal_sols)
 function update_lp_dual_sol!(state::OptimizationState{F, S}, sol::DualSolution{F}) where {F, S}
     state.max_length_lp_dual_sols == 0 && return
     b = DualBound{S}(getvalue(sol))
-    if update_lp_dual_bound!(state.incumbents, b)
+    if update_lp_dual_bound!(state, b)
         state.insert_function_lp_dual_sols(state.lp_dual_sols, state.max_length_lp_dual_sols, sol)
     end
     return
@@ -327,7 +376,7 @@ function add_lp_dual_sol!(state::OptimizationState{F, S}, sol::DualSolution{F}) 
     state.max_length_lp_dual_sols == 0 && return
     state.insert_function_lp_dual_sols(state.lp_dual_sols, state.max_length_lp_dual_sols, sol)
     b = DualBound{S}(getvalue(sol))
-    update_lp_dual_bound!(state.incumbents, b)
+    update_lp_dual_bound!(state, b)
     return
 end
 

--- a/src/ColunaBase/solsandbounds.jl
+++ b/src/ColunaBase/solsandbounds.jl
@@ -40,7 +40,8 @@ isbetter(b1::Bound{Sp,Se}, b2::Bound{Sp,Se}) where {Sp<:Dual,Se<:MinSense} = b1.
 isbetter(b1::Bound{Sp,Se}, b2::Bound{Sp,Se}) where {Sp<:Dual,Se<:MaxSense} = b1.value < b2.value
 
 """
-    diff(b1, b2)
+    diff(pb, db)
+    diff(db, pb)
 
 Distance between a primal bound and a dual bound that have the same objective sense.
 Distance is non-positive if dual bound reached primal bound.
@@ -62,9 +63,10 @@ function Base.diff(db::Bound{<:Dual,<:MaxSense}, pb::Bound{<:Primal,<:MaxSense})
 end
 
 """
-    gap
+    gap(pb, db)
+    gap(db, pb)
 
-relative gap. Gap is non-positive if pb reached db
+Return relative gap. Gap is non-positive if pb reached db.
 """
 function gap(pb::Bound{<:Primal,<:MinSense}, db::Bound{<:Dual,<:MinSense})
     return diff(pb, db) / abs(db.value)

--- a/src/MOIwrapper.jl
+++ b/src/MOIwrapper.jl
@@ -683,7 +683,7 @@ function MOI.get(optimizer::Optimizer, ::MOI.RawStatusString)
 end
 
 function MOI.get(optimizer::Optimizer, ::MOI.ResultCount)
-    return nb_ip_primal_sols(optimizer.result)
+    return length(get_ip_primal_sols(optimizer.result))
 end
 
 function MOI.get(

--- a/src/MathProg/MathProg.jl
+++ b/src/MathProg/MathProg.jl
@@ -100,12 +100,7 @@ export Variable, Constraint, VarId, ConstrId, VarMembership, ConstrMembership,
     isexplicit, getname, getbranchingpriority, reset!, getreducedcost
 
 # Types & methods related to solutions & bounds
-export PrimalBound, DualBound, PrimalSolution, DualSolution, ObjValues,
-    get_ip_primal_bound, get_lp_primal_bound,
-    get_ip_dual_bound, get_lp_dual_bound, update_ip_primal_bound!, update_lp_primal_bound!,
-    update_ip_dual_bound!, update_lp_dual_bound!, set_ip_primal_bound!,
-    set_lp_primal_bound!, set_ip_dual_bound!, set_lp_dual_bound!, ip_gap, lp_gap, ip_gap_closed, 
-    lp_gap_closed
+export PrimalBound, DualBound, PrimalSolution, DualSolution, ObjValues
 
 # Methods related to projections
 export projection_is_possible, proj_cols_on_rep

--- a/test/MathOptInterface/MOI_wrapper.jl
+++ b/test/MathOptInterface/MOI_wrapper.jl
@@ -48,16 +48,16 @@ end
     model = BlockModel(coluna, direct_model=true)
     @variable(model, x)
     
-    @test BlockDecomposition.branchingpriority(model, x) == 1
-    BlockDecomposition.branchingpriority!(model, x, 2)
-    @test BlockDecomposition.branchingpriority(model, x) == 2
+    @test BlockDecomposition.branchingpriority(x) == 1
+    BlockDecomposition.branchingpriority!(x, 2)
+    @test BlockDecomposition.branchingpriority(x) == 2
     
     model2 = BlockModel(coluna)
     @variable(model2, x)
     
-    @test BlockDecomposition.branchingpriority(model2, x) == 1
-    BlockDecomposition.branchingpriority!(model2, x, 2)
-    @test BlockDecomposition.branchingpriority(model2, x) == 2
+    @test BlockDecomposition.branchingpriority(x) == 1
+    BlockDecomposition.branchingpriority!(x, 2)
+    @test BlockDecomposition.branchingpriority(x) == 2
 end
 
 @testset "write_to_file" begin

--- a/test/full_instances_tests.jl
+++ b/test/full_instances_tests.jl
@@ -84,7 +84,7 @@ function generalized_assignment_tests()
         # we increase the branching priority of variables which assign jobs to the first two machines
         for machine in 1:2
             for job in data.jobs
-                BD.branchingpriority!(model, x[machine,job], 2)
+                BD.branchingpriority!(x[machine,job], 2)
             end
         end  
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,4 @@
+using Base.CoreLogging: Error
 using Coluna
 
 using Test, GLPK, ColunaDemos, JuMP, BlockDecomposition

--- a/test/unit/MathProg/bounds.jl
+++ b/test/unit/MathProg/bounds.jl
@@ -1,0 +1,68 @@
+function mathprog_bounds()
+    env = Coluna.Env(Coluna.Params())
+
+    min_form = Coluna.MathProg.create_formulation!(
+        env, Coluna.MathProg.Original();
+        obj_sense = Coluna.MathProg.MinSense
+    )
+
+    max_form = Coluna.MathProg.create_formulation!(
+        env, Coluna.MathProg.Original();
+        obj_sense = Coluna.MathProg.MaxSense
+    )
+
+    @testset "Primal bound constructor" begin
+        pb1 = Coluna.MathProg.PrimalBound(min_form)
+        @test pb1 == Inf
+        pb2 = Coluna.MathProg.PrimalBound(max_form)
+        @test pb2 == -Inf
+        pb3 = Coluna.MathProg.PrimalBound(min_form, 10)
+        @test pb3 == 10
+        @test_throws ErrorException Coluna.MathProg.PrimalBound(max_form, pb3)
+    end
+
+    @testset "Dual bound constructor" begin
+        db1 = Coluna.MathProg.DualBound(min_form)
+        @test db1 == -Inf
+        db2 = Coluna.MathProg.DualBound(max_form)
+        @test db2 == Inf
+        db3 = Coluna.MathProg.DualBound(min_form, 150)
+        @test db3 == 150
+        @test_throws ErrorException Coluna.MathProg.DualBound(max_form, db3)
+    end
+
+    @testset "ObjValues constructor & private methods" begin
+        obj = ObjValues(
+            min_form;
+            ip_primal_bound = 15.0,
+            ip_dual_bound = 12.0,
+            lp_primal_bound = 66,
+            lp_dual_bound = π
+        )
+
+        @test obj.ip_primal_bound == 15.0
+        @test obj.ip_dual_bound == 12.0
+        @test obj.lp_primal_bound == 66
+        @test obj.lp_dual_bound == float(π) # precision...
+
+        # Gap methods are already tested in containers/solsandbounds.jl
+
+        @test Coluna.MathProg._update_ip_primal_bound!(obj, PrimalBound(min_form, 16.0)) == false
+        @test Coluna.MathProg._update_ip_primal_bound!(obj, PrimalBound(min_form, 14.0)) == true
+
+        @test Coluna.MathProg._update_lp_primal_bound!(obj, PrimalBound(min_form, 67.0)) == false
+        @test Coluna.MathProg._update_lp_primal_bound!(obj, PrimalBound(min_form, 65.0)) == true
+
+        @test Coluna.MathProg._update_ip_dual_bound!(obj, DualBound(min_form, 11.0)) == false
+        @test Coluna.MathProg._update_ip_dual_bound!(obj, DualBound(min_form, 13.0)) == true
+
+        @test Coluna.MathProg._update_lp_dual_bound!(obj, DualBound(min_form, 3.0)) == false
+        @test Coluna.MathProg._update_lp_dual_bound!(obj, DualBound(min_form, 3.2)) == true
+
+        @test obj.ip_primal_bound == 14.0
+        @test obj.ip_dual_bound == 13.0
+        @test obj.lp_primal_bound == 65
+        @test obj.lp_dual_bound == 3.2
+    end
+    return
+end

--- a/test/unit/unit_tests.jl
+++ b/test/unit/unit_tests.jl
@@ -5,6 +5,7 @@ include("MathProg/buffer.jl")
 include("MathProg/formulations.jl")
 include("MathProg/types.jl")
 include("MathProg/variables.jl")
+include("MathProg/bounds.jl")
 
 include("variable.jl")
 include("constraint.jl")
@@ -21,11 +22,13 @@ function unit_tests()
         max_nb_form_unit()
         types_unit_tests()
         variables_unit_tests()
+        mathprog_bounds()
     end
 
     @testset "variable.jl" begin
         variable_unit_tests()
     end
+    
     @testset "constraint.jl" begin
         constraint_unit_tests()
     end

--- a/test/user_algorithms_tests.jl
+++ b/test/user_algorithms_tests.jl
@@ -9,7 +9,7 @@ end
 @with_kw struct ConsecutiveColGen <: AbstractOptimizationAlgorithm
     colgen = ColumnGeneration(smoothing_stabilization = 1.0)
     preprocess = PreprocessAlgorithm(preprocess_subproblems = true, printing = true)
-    rm_heur = RestrictedMasterHeuristic()
+    rm_heur = RestrictedMasterIPHeuristic()
     num_calls_to_col_gen = 3  
 end
 

--- a/test/user_algorithms_tests.jl
+++ b/test/user_algorithms_tests.jl
@@ -39,7 +39,7 @@ function Coluna.Algorithm.run!(
 
         cg_output = run!(algo.colgen, env, reform, OptimizationInput(optstate))
         cg_optstate = getoptstate(cg_output)
-        update_all_ip_primal_solutions!(optstate, cg_optstate)
+        add_ip_primal_sols!(optstate, get_ip_primal_sols(cg_optstate)...)
 
         primal_sol = get_best_lp_primal_sol(cg_optstate)
 
@@ -65,7 +65,7 @@ function Coluna.Algorithm.run!(
     end
 
     heur_output = run!(algo.rm_heur, env, reform, OptimizationInput(optstate))
-    update_all_ip_primal_solutions!(optstate, getoptstate(heur_output))
+    add_ip_primal_sols!(optstate, get_ip_primal_sols(getoptstate(heur_output))...)
 
     return OptimizationOutput(optstate)
 end


### PR DESCRIPTION
- `ObjValues` is used only in `OptimizationState`, so I moved all the docstring in `OptimizationState` methods.
- tests & doc for PrimalBound, DualBound and ObjValues
- remove some duplicated methods
- I fixed a bug I introduced in #543 
- Fix CI