### PR TITLE
Add support for `AffExpr, MathOptInterface.Interval{Float64}`

### DIFF
--- a/src/MOIwrapper.jl
+++ b/src/MOIwrapper.jl
@@ -437,6 +437,15 @@ function MOI.set(
 end
 
 function MOI.set(
+    model::MOI.Bridges.LazyBridgeOptimizer{Coluna.Optimizer}, ::BD.ConstraintDecomposition,
+    bridge::MOI.Bridges.Constraint.SplitIntervalBridge, annotation::BD.Annotation
+)
+    MOI.set(model.model, BD.ConstraintDecomposition(), bridge.lower, annotation)
+    MOI.set(model.model, BD.ConstraintDecomposition(), bridge.upper, annotation)
+    return
+end
+
+function MOI.set(
     model::Coluna.Optimizer, ::MOI.ConstraintName, constrid::MOI.ConstraintIndex{F,S}, name::String
 ) where {F<:MOI.ScalarAffineFunction,S}
     MOI.throw_if_not_valid(model, constrid)

--- a/src/MOIwrapper.jl
+++ b/src/MOIwrapper.jl
@@ -426,6 +426,15 @@ end
 # Attributes of constraints
 ############################################################################################
 function MOI.set(
+    model::MOI.Bridges.LazyBridgeOptimizer{Coluna.Optimizer}, attr::MOI.AbstractConstraintAttribute,
+    bridge::MOI.Bridges.Constraint.SplitIntervalBridge, value
+)
+    MOI.set(model.model, attr, bridge.lower, value)
+    MOI.set(model.model, attr, bridge.upper, value)
+    return
+end
+
+function MOI.set(
     model::Coluna.Optimizer, ::BD.ConstraintDecomposition, constrid::MOI.ConstraintIndex,
     annotation::BD.Annotation
 )
@@ -433,15 +442,6 @@ function MOI.set(
     if constr !== nothing
         store!(model.annotations, annotation, model.constrs[constrid])
     end
-    return
-end
-
-function MOI.set(
-    model::MOI.Bridges.LazyBridgeOptimizer{Coluna.Optimizer}, ::BD.ConstraintDecomposition,
-    bridge::MOI.Bridges.Constraint.SplitIntervalBridge, annotation::BD.Annotation
-)
-    MOI.set(model.model, BD.ConstraintDecomposition(), bridge.lower, annotation)
-    MOI.set(model.model, BD.ConstraintDecomposition(), bridge.upper, annotation)
     return
 end
 

--- a/test/MathOptInterface/MOI_wrapper.jl
+++ b/test/MathOptInterface/MOI_wrapper.jl
@@ -89,12 +89,6 @@ end
 end
 
 @testset "SplitIntervalBridge" begin
-    nb_machines = 1
-    nb_jobs = 1
-    b = [1.0]
-    w = [1.0]
-    Q = [2]
-
     coluna = optimizer_with_attributes(
         Coluna.Optimizer,
         "params" => Coluna.Params(
@@ -103,14 +97,13 @@ end
         "default_optimizer" => GLPK.Optimizer
     )
 
-    @axis(M, 1:nb_machines)
-    J = 1:nb_jobs
+    @axis(M, 1:1)
+    J = 1:1
 
     model = BlockModel(coluna)
     @variable(model, x[m in M, j in J])
-    @constraint(model, mult[j in J], 0 <= sum(x[m,j] for m in M) <= 2)
-    @constraint(model, cap[m in M], sum(w[j]*x[m,j] for j in J) <= Q[m])
-    @objective(model, Max, sum(b[m,j]*x[m,j] for m in M, j in J))
+    @constraint(model, mult[m in M], 1 <= sum(x[m,j] for j in J) <= 2)
+    @objective(model, Max, sum(x[m,j] for m in M, j in J))
 
     @dantzig_wolfe_decomposition(model, decomposition, M)
 


### PR DESCRIPTION
fix #563 

I hoped to find a method like this in MOI:

```julia
function MOI.set(
    model::MOI.ModelLike,
    attr::MOI.AbstractConstraintAttribute,
    bridge::SplitIntervalBridge,
    value,
)
    MOI.set(model, attr, bridge.lower, value)
    MOI.set(model, attr, bridge.upper, value)
end
```

But I couldn't find any. The fallback we get (https://github.com/jump-dev/MathOptInterface.jl/blob/978096044b3ab89ae57e778c9369f2198dba49af/src/Bridges/bridge.jl#L120) seems to confirm it is necessary to add a new set method at least for `SplitIntervalBridge`.