### PR TITLE
Rm warnings if cost of artificial vars not provided by the user

### DIFF
--- a/src/optimize.jl
+++ b/src/optimize.jl
@@ -13,11 +13,6 @@ function _adjust_params(params, init_pb)
             params.global_art_var_cost = 10^(exp + 1)
         else
             params.global_art_var_cost = 100000.0
-            msg = """
-            No initial primal bound and no cost for global artificial variables.
-            Cost of global artificial variables set to 100000.0
-            """
-            @warn(msg)
         end
     end
     if params.local_art_var_cost === nothing
@@ -26,11 +21,6 @@ function _adjust_params(params, init_pb)
             params.local_art_var_cost = 10^exp
         else
             params.local_art_var_cost = 10000.0
-            msg = """
-            No initial primal bound and no cost for local artificial variables.
-            Cost of local artificial variables set to 10000.0
-            """
-            @warn(msg)
         end
     end
     return


### PR DESCRIPTION
These warnings are misleading (cf https://github.com/atoptima/Coluna.jl/issues/545#issuecomment-860415524)