### PR TITLE
create_hash always returns int

### DIFF
--- a/src/MathProg/vcids.jl
+++ b/src/MathProg/vcids.jl
@@ -22,9 +22,9 @@ end
 
 function _create_hash(uid::Integer, origin_form_uid::Integer, proc_uid::Integer)
     return (
-        uid * MAX_NB_FORMULATIONS * MAX_NB_PROCESSES
-        + origin_form_uid * MAX_NB_PROCESSES
-        + proc_uid
+        Int(uid) * Int(MAX_NB_FORMULATIONS) * Int(MAX_NB_PROCESSES)
+        + Int(origin_form_uid) * Int(MAX_NB_PROCESSES)
+        + Int(proc_uid)
     )
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,7 +19,6 @@ const ClA = Coluna.Algorithm
 
 
 include("unit/unit_tests.jl")
-include("MathOptInterface/MOI_wrapper.jl")
 include("interfaces/model.jl")
 include("issues_tests.jl")
 include("show_functions_tests.jl")
@@ -37,6 +36,7 @@ include("node_finalizer_tests.jl")
 rng = MersenneTwister(1234123)
 
 unit_tests()
+
 test_issues_fixed()
 
 @testset "Full instances " begin
@@ -89,3 +89,5 @@ end
 
     node_finalizer_tests(true)  # heuristic node finalizer
 end
+
+include("MathOptInterface/MOI_wrapper.jl")

--- a/test/unit/MathProg/vcids.jl
+++ b/test/unit/MathProg/vcids.jl
@@ -8,7 +8,7 @@ function vcids_unit_tests()
         hash2 = Coluna.MathProg._create_hash(Int8(uid), Int16(origin_form_uid), Int32(proc_uid))
         hash3 = Coluna.MathProg._create_hash(UInt16(uid), Int8(origin_form_uid), Int8(proc_uid))
 
-        @test hash1 == hash2
-        @test hash2 == hash3
+        @test hash1 === hash2
+        @test hash2 === hash3
     end
 end

--- a/test/unit/MathProg/vcids.jl
+++ b/test/unit/MathProg/vcids.jl
@@ -1,0 +1,14 @@
+function vcids_unit_tests()
+    @testset "_create_hash" begin
+        uid = 1
+        origin_form_uid = 2
+        proc_uid = 3
+
+        hash1 = Coluna.MathProg._create_hash(uid, origin_form_uid, proc_uid)
+        hash2 = Coluna.MathProg._create_hash(Int8(uid), Int16(origin_form_uid), Int32(proc_uid))
+        hash3 = Coluna.MathProg._create_hash(UInt16(uid), Int8(origin_form_uid), Int8(proc_uid))
+
+        @test hash1 == hash2
+        @test hash2 == hash3
+    end
+end

--- a/test/unit/unit_tests.jl
+++ b/test/unit/unit_tests.jl
@@ -6,6 +6,7 @@ include("MathProg/formulations.jl")
 include("MathProg/types.jl")
 include("MathProg/variables.jl")
 include("MathProg/bounds.jl")
+include("MathProg/vcids.jl")
 
 include("variable.jl")
 include("constraint.jl")
@@ -37,6 +38,10 @@ function unit_tests()
 
     @testset "optimizationstate.jl" begin
         optstate_unit_tests()
+    end
+
+    @testset "vcids.jl" begin
+        vcids_unit_tests()
     end
     
     return


### PR DESCRIPTION
This is a critical bug. A patch release will follow.