### PR TITLE
Branching API documentation

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -49,6 +49,7 @@ makedocs(
         "API" => Any[
             "Tree Search" => joinpath("api", "treesearch.md"),
             "Storage" => joinpath("api", "storage.md"),
+            "Branching" => joinpath("api", "branching.md"),
         ],
         "Q&A" => "qa.md",
     ]

--- a/docs/src/api/branching.md
+++ b/docs/src/api/branching.md
@@ -1,0 +1,142 @@
+```@meta
+CurrentModule = Coluna.Algorithm
+DocTestSetup = quote
+    using Coluna.Algorithm
+end
+```
+
+# Branching API
+
+Coluna provides default implementations for the branching algorithm and the strong branching algorithms.
+Both implementations are built on top of an API that we describe here.
+
+## Candidates selection
+
+Candidates selection is the first step (and sometimes the only step) of any branching algorithm.
+It chooses what are the possible branching constraints that will generate
+the children of the current node of the branch-and-bound tree.
+
+Coluna provides the following function for this step:
+
+```@docs
+select!
+```
+
+It works as follows.
+
+The user chooses one or several branching rules that indicate the type of branching he want
+to perform.
+This may be on a single variable or on a linear expression of variables for instance. 
+
+The branching rule must implement `apply_branching_rule` that generates the candidates. 
+The latter are the variables or expressions on which the branch-and-bound may branch with
+additional information that are requested by Coluna's branching implementation through the
+API.
+
+Then, candidates are sorted according to a selection criterion (e.g. most fractional).
+The algorithm keeps a certain number of candidates (one for a classic branching, several for a strong branching).
+It generates the children of each candidate kept.
+At last, it returns the candidates kept.
+
+### Branching rule
+
+```@docs
+AbstractBranchingRule
+apply_branching_rule
+```
+
+### Candidate
+
+```@docs
+AbstractBranchingCandidate
+getdescription
+get_lhs
+get_local_id
+get_children
+set_children!
+get_parent
+generate_children!
+```
+
+### Selection criterion
+
+```@docs
+AbstractSelectionCriterion
+select_candidates!
+```
+
+### Branching API
+
+```@docs
+get_selection_nb_candidates
+branching_context_type
+new_context
+get_int_tol
+get_rules
+get_selection_criterion
+```
+
+Method `advanced_select!` is part of the API but presented just below.
+
+## Advanced candidates selection
+
+If the candidates selection returns several candidates will all their children, advanced candidates selection must keep only one of them.
+
+The advanced candidates selection is the place to evaluate the children to get relevant
+additional kpis about each branching candidates.
+
+Coluna provides the following function for this step.
+
+```@docs
+advanced_select!
+```
+
+Coluna has two default implementation for this method:
+- for the classic branching that does nothing because the candidates selection returns 1 candidate
+- for the strong branching that performs several evaluation of the candidates.
+
+Let us focus on the strong branching. 
+Strong branching is a procedure that heuristically selects a branching constraint that
+potentially gives the best progress of the dual bound.
+The procedure selects a collection of branching candidates based on their branching rule
+(done in classic candidate selection) 
+and their score (done in advances candidate selection).
+Then, the procedure evaluates the progress of the dual bound in both branches of each branching
+candidate by solving both potential children using a conquer algorithm.
+The candidate that has the largest score is chosen to be the branching constraint.
+
+However, the score can be difficult to compute. For instance, when the score is based
+dual bound improvement produced by the branching constraint which is time-consuming to
+evaluate in the context of column generation
+Therefore, one can let the branching algorithm quickly estimate the score of each candidate 
+and retain the most promising branching candidates. 
+This is called a **phase**. The goal is to first evaluate a large number
+of candidates with a very fast conquer algorithm and retain a certain number of promising ones. 
+Then, over the phases, it evaluates the improvement with a more precise conquer algorithm and
+restrict the number of retained candidates until only one is left.
+
+### Strong Branching API
+
+```@docs
+get_units_to_restore_for_conquer
+get_phases
+get_score
+get_conquer
+get_max_nb_candidates
+```
+
+Following methods are part of the API but have default implementation.
+We advise to not change them.
+
+```@docs
+perform_branching_phase!
+eval_children_of_candidate!
+eval_child_of_candidate!
+```
+
+#### Score
+
+```@docs
+AbstractBranchingScore
+compute_score
+```

--- a/src/Algorithm/branching/interface.jl
+++ b/src/Algorithm/branching/interface.jl
@@ -14,10 +14,19 @@ getdescription(candidate::AbstractBranchingCandidate) =
 ## Note: Branching candidates must be created in the BranchingRule algorithm so they do not need
 ## a generic constructor.
 
+"Returns the left-hand side of the candidate."
 @mustimplement "BranchingCandidate" get_lhs(c::AbstractBranchingCandidate)
+
+"Returns the generation id of the candidiate."
 @mustimplement "BranchingCandidate" get_local_id(c::AbstractBranchingCandidate)
+
+"Returns the children of the candidate."
 @mustimplement "BranchingCandidate" get_children(c::AbstractBranchingCandidate)
+
+"Set the children of the candidate."
 @mustimplement "BranchingCandidate" set_children!(c::AbstractBranchingCandidate, children)
+
+"Returns the parent node of the candidate's children."
 @mustimplement "BranchingCandidate" get_parent(c::AbstractBranchingCandidate)
 
 # TODO: this method should not generate the children of the tree search algorithm.
@@ -44,24 +53,26 @@ candidates. To create a new selection criterion, one needs to create a subtype o
 """
 abstract type AbstractSelectionCriterion end
 
-"""
-    select_candidates!(branching_candidates, selection_criterion, max_nb_candidates)
-
-Sort branching candidates according to the selection criterion and remove excess ones.
-"""
+"Sort branching candidates according to the selection criterion and remove excess ones."
 @mustimplement "BranchingSelection" select_candidates!(::Vector{<:AbstractBranchingCandidate}, selection::AbstractSelectionCriterion, ::Int)
 
 ############################################################################################
 # Branching score
 ############################################################################################
-
+"""
+Supertype of branching scores.
+"""
 abstract type AbstractBranchingScore end
 
+"Returns the score of a candidate."
 @mustimplement "BranchingScore" compute_score(::AbstractBranchingScore, candidate)
 
 ############################################################################################
 # BranchingRuleAlgorithm
 ############################################################################################
+"""
+Supertype of branching rules.
+"""
 abstract type AbstractBranchingRule <: AbstractAlgorithm end
 
 """
@@ -83,11 +94,11 @@ end
 Input of a branching rule (branching separation algorithm)
 Contains current solution, max number of candidates and local candidate id.
 """
-struct BranchingRuleInput{Node<:AbstractNode}
+struct BranchingRuleInput{SelectionCriterion<:AbstractSelectionCriterion,Node<:AbstractNode}
     solution::PrimalSolution 
     isoriginalsol::Bool
     max_nb_candidates::Int64
-    criterion::AbstractSelectionCriterion
+    criterion::SelectionCriterion
     local_id::Int64
     int_tol::Float64
     minimum_priority::Float64
@@ -106,8 +117,10 @@ end
 # branching rules are always manager algorithms (they manage storing and restoring storage units)
 ismanager(algo::AbstractBranchingRule) = true
 
+"Returns all candidates that satisfy a given branching rule."
 apply_branching_rule(rule, env, reform, input) = nothing
 
+"Candidates selection for branching algorithms."
 function select!(rule::AbstractBranchingRule, env::Env, reform::Reformulation, input::BranchingRuleInput)
     candidates = apply_branching_rule(rule, env, reform, input)
     local_id = input.local_id + length(candidates)


### PR DESCRIPTION
Documentation of the branching API.

We may need to isolate APIs in different submodules because a few functions may have the same name in different APIs. It's confusing.