### PR TITLE
Fix variable of formulation

### DIFF
--- a/src/MathProg/MathProg.jl
+++ b/src/MathProg/MathProg.jl
@@ -91,7 +91,7 @@ export Variable, Constraint, VarId, ConstrId, VarMembership, ConstrMembership,
     getperenub, getcurub, setcurub!, getperenrhs, setperenrhs!, getcurrhs, setcurrhs!, getperensense, setperensense!,
     getcursense, setcursense!, getperenkind, getcurkind, setcurkind!, getperenincval,
     getcurincval, setcurincval!, isperenactive, iscuractive, activate!, deactivate!,
-    isexplicit, getname, getbranchingpriority, reset!, getreducedcost, setperenkind!
+    isexplicit, getname, getbranchingpriority, reset!, getreducedcost, setperenkind!, isfixed, fix!
 
 # Types & methods related to solutions & bounds
 export PrimalBound, DualBound, AbstractSolution, PrimalSolution, DualSolution, ActiveBound, ObjValues,

--- a/src/MathProg/formulation.jl
+++ b/src/MathProg/formulation.jl
@@ -215,7 +215,7 @@ function setvar!(
         name = string("v_", getuid(id))
     end
 
-    v_data = VarData(cost, lb, ub, kind, inc_val, is_active, is_explicit)
+    v_data = VarData(cost, lb, ub, kind, inc_val, is_active, is_explicit, false)
 
     var = Variable(
         id, name;

--- a/src/MathProg/variable.jl
+++ b/src/MathProg/variable.jl
@@ -8,6 +8,7 @@ mutable struct VarData <: AbstractVcData
     inc_val::Float64
     is_active::Bool
     is_explicit::Bool
+    is_fixed::Bool
 end
 
 """
@@ -19,12 +20,12 @@ function VarData(
     ;cost::Float64 = 0.0, lb::Float64 = 0.0, ub::Float64 = Inf, kind::VarKind = Continuous,
     inc_val::Float64 = -1.0, is_active::Bool = true, is_explicit::Bool = true
 )
-    vc = VarData(cost, lb, ub, kind, inc_val, is_active, is_explicit)
+    vc = VarData(cost, lb, ub, kind, inc_val, is_active, is_explicit, false)
     return vc
 end
 
 VarData(vd::VarData) = VarData(
-    vd.cost, vd.lb, vd.ub, vd.kind, vd.inc_val, vd.is_active, vd.is_explicit
+    vd.cost, vd.lb, vd.ub, vd.kind, vd.inc_val, vd.is_active, vd.is_explicit, vd.is_fixed
 )
 
 """

--- a/test/unit/MathProg/variables.jl
+++ b/test/unit/MathProg/variables.jl
@@ -136,4 +136,118 @@
         @test ClMP.getindex(v_rec) == ClMP.MoiVarIndex(-20)
         @test ClMP.getbounds(v_rec) == ClMP.MoiVarBound(10)
     end
+
+    @testset "fix variable 1" begin
+        form = ClMP.create_formulation!(Env{ClMP.VarId}(Coluna.Params()), ClMP.Original())
+        var = ClMP.setvar!(
+            form, "var1", ClMP.OriginalVar, cost = 2.0, lb = -1.0, ub = 1.0, 
+            kind = ClMP.Integ, inc_val = 4.0
+        )
+
+        varid = ClMP.getid(var)
+        
+        @test iscuractive(form, var)
+        @test isexplicit(form, var)
+        @test !isfixed(form, var)
+        @test !in(varid, form.manager.fixed_vars)
+
+        fix!(form, var, 0.0)
+        @test getcurub(form, var) == 0
+        @test getcurlb(form, var) == 0
+        @test getperenub(form, var) == 1
+        @test getperenlb(form, var) == -1
+        @test isfixed(form, var)
+        @test !iscuractive(form, var)
+        @test in(varid, form.manager.fixed_vars)
+
+        setcurlb!(form, var, -1)
+        @test getcurub(form, var) == 0
+        @test getcurlb(form, var) == -1
+        @test getperenub(form, var) == 1
+        @test getperenlb(form, var) == -1
+        @test !isfixed(form, var)
+        @test iscuractive(form, var)
+        @test !in(varid, form.manager.fixed_vars)
+    end
+
+    @testset "fix variable 2" begin
+        form = ClMP.create_formulation!(Env{ClMP.VarId}(Coluna.Params()), ClMP.Original())
+        var = ClMP.setvar!(
+            form, "var1", ClMP.OriginalVar, cost = 2.0, lb = -1.0, ub = 1.0, 
+            kind = ClMP.Integ, inc_val = 4.0
+        )
+
+        varid = ClMP.getid(var)
+        
+        @test iscuractive(form, var)
+        @test isexplicit(form, var)
+        @test !isfixed(form, var)
+        @test !in(varid, form.manager.fixed_vars)
+
+        fix!(form, var, 0.0)
+        @test getcurub(form, var) == 0
+        @test getcurlb(form, var) == 0
+        @test getperenub(form, var) == 1
+        @test getperenlb(form, var) == -1
+        @test isfixed(form, var)
+        @test !iscuractive(form, var)
+        @test in(varid, form.manager.fixed_vars)
+
+        setcurub!(form, var, 1)
+        @test getcurub(form, var) == 1
+        @test getcurlb(form, var) == 0
+        @test getperenub(form, var) == 1
+        @test getperenlb(form, var) == -1
+        @test !isfixed(form, var)
+        @test iscuractive(form, var)
+        @test !in(varid, form.manager.fixed_vars)
+    end
+
+    @testset "fix variable 3" begin
+        form = ClMP.create_formulation!(Env{ClMP.VarId}(Coluna.Params()), ClMP.Original())
+        var = ClMP.setvar!(
+            form, "var1", ClMP.OriginalVar, cost = 2.0, lb = -1.0, ub = 1.0, 
+            kind = ClMP.Integ, inc_val = 4.0
+        )
+
+        varid = ClMP.getid(var)
+        deactivate!(form, varid)
+        @test !iscuractive(form, varid)
+        fix!(form, varid, 0)  # try to fix an unactive variable -> should not work.
+        @test !isfixed(form, varid)
+        @test getcurub(form, var) == 1
+        @test getcurlb(form, var) == -1
+        @test getperenub(form, var) == 1
+        @test getperenlb(form, var) == -1
+    end
+
+    @testset "fix variable 4" begin
+        # sequential fix
+        form = ClMP.create_formulation!(Env{ClMP.VarId}(Coluna.Params()), ClMP.Original())
+        var = ClMP.setvar!(
+            form, "var1", ClMP.OriginalVar, cost = 2.0, lb = -1.0, ub = 1.0, 
+            kind = ClMP.Integ, inc_val = 4.0
+        )
+
+        varid = ClMP.getid(var)
+        @test !in(varid, form.manager.fixed_vars)
+
+        fix!(form, var, 0.0)
+        @test getcurub(form, var) == 0
+        @test getcurlb(form, var) == 0
+        @test getperenub(form, var) == 1
+        @test getperenlb(form, var) == -1
+        @test isfixed(form, var)
+        @test !iscuractive(form, var)
+        @test in(varid, form.manager.fixed_vars)
+
+        fix!(form, var, 1.0)
+        @test getcurub(form, var) == 1
+        @test getcurlb(form, var) == 1
+        @test getperenub(form, var) == 1
+        @test getperenlb(form, var) == -1
+        @test isfixed(form, var)
+        @test !iscuractive(form, var)
+        @test in(varid, form.manager.fixed_vars)
+    end
 end


### PR DESCRIPTION
Now, you can fix an active and explicit variable in a formulation.
Fixing a variable means it has the same lower and upper bound and it is then deactivated until one of its bounds changes.