### PR TITLE
enforce convergence condition

### DIFF
--- a/src/ColGen/interface.jl
+++ b/src/ColGen/interface.jl
@@ -61,7 +61,7 @@ function run_colgen_phase!(context, phase, stage, env, ip_primal_sol; iter = 1)
         iteration += 1
     end
     O = colgen_phase_output_type(context)
-    return new_phase_output(O, phase, stage, colgen_iter_output, iteration)
+    return new_phase_output(O, is_minimization(context), phase, stage, colgen_iter_output, iteration)
 end
 
 function run!(context, env, ip_primal_sol; iter = 1)
@@ -237,7 +237,7 @@ abstract type AbstractColGenIterationOutput end
 
 @mustimplement "ColGenIterationOutput" get_master_ip_primal_sol(::AbstractColGenIterationOutput) = nothing
 
-@mustimplement "ColGenPhaseOutput" new_phase_output(::Type{<:AbstractColGenPhaseOutput}, phase, stage, ::AbstractColGenIterationOutput, iteration) = nothing
+@mustimplement "ColGenPhaseOutput" new_phase_output(::Type{<:AbstractColGenPhaseOutput}, min_sense, phase, stage, ::AbstractColGenIterationOutput, iteration) = nothing
 
 @mustimplement "ColGenPhaseOutput" get_master_ip_primal_sol(::AbstractColGenPhaseOutput) = nothing
 

--- a/test/unit/ColGen/colgen_phase.jl
+++ b/test/unit/ColGen/colgen_phase.jl
@@ -494,7 +494,8 @@ function infeasible_phase_output()
         true, #infeasible
         true, #exact_stage
         false,
-        6
+        6,
+        true
     )
 
     @test ColGen.stop_colgen(ctx, colgen_phase_output)


### PR DESCRIPTION
I changed the ColGenPhaseOutput structure to add a field `min_sense` (boolean). I use it to enforce the convergence condition in `colgen_has_converged` (I add the condition `( (output.min_sense) && (output.db >= output.mlp) ) || ( !(output.min_sense) && (output.db <= output.mlp) )` to the condition `abs(output.mlp - output.db) < 1e-5`

Remark: if I change the old condition `abs(output.mlp - output.db) < 1e-5` by new condition `( (output.min_sense) && (output.db >= output.mlp) ) || ( !(output.min_sense) && (output.db <= output.mlp) ),` test `gap_with_all_phases_in_colgen` failed (see log) 

[message.txt](https://github.com/atoptima/Coluna.jl/files/11396121/message.txt)
