### PR TITLE
`Interval` -> `GreaterThan` & `LowerThan`

### DIFF
--- a/src/MathProg/MOIinterface.jl
+++ b/src/MathProg/MOIinterface.jl
@@ -21,7 +21,8 @@ function update_bounds_in_optimizer!(form::Formulation, optimizer::MoiOptimizer,
     inner = getinner(optimizer)
     moi_record = getmoirecord(var)
     moi_kind = getkind(moi_record)
-    moi_bounds = getbounds(moi_record)
+    moi_lower_bound = getlowerbound(moi_record)
+    moi_upper_bound = getupperbound(moi_record)
     moi_index = getindex(moi_record)
     if getcurkind(form, var) == Binary && moi_index.value != -1
         MOI.delete(inner, moi_kind)
@@ -29,14 +30,22 @@ function update_bounds_in_optimizer!(form::Formulation, optimizer::MoiOptimizer,
             inner, MOI.VariableIndex(moi_index), MOI.Integer()
         ))
     end
-    if moi_bounds.value != -1
-        MOI.set(inner, MOI.ConstraintSet(), moi_bounds,
-            MOI.Interval(getcurlb(form, var), getcurub(form, var))
+    if moi_lower_bound.value != -1
+        MOI.set(inner, MOI.ConstraintSet(), moi_lower_bound,
+            MOI.GreaterThan(getcurlb(form, var))
         )
     else
-        setbounds!(moi_record, MOI.add_constraint(
-            inner, MOI.VariableIndex(moi_index),
-            MOI.Interval(getcurlb(form, var), getcurub(form, var))
+        setlowerbound!(moi_record, MOI.add_constraint(
+            inner, MOI.VariableIndex(moi_index), MOI.GreaterThan(getcurlb(form, var))
+        ))
+    end
+    if moi_upper_bound.value != -1
+        MOI.set(inner, MOI.ConstraintSet(), moi_upper_bound,
+            MOI.LessThan(getcurub(form, var))
+        )
+    else
+        setupperbound!(moi_record, MOI.add_constraint(
+            inner, MOI.VariableIndex(moi_index), MOI.LessThan(getcurub(form, var))
         ))
     end
     return
@@ -78,11 +87,16 @@ function enforce_bounds_in_optimizer!(
     form::Formulation, optimizer::MoiOptimizer, var::Variable
 )
     moirecord = getmoirecord(var)
-    moi_bounds = MOI.add_constraint(
+    moi_lower_bound = MOI.add_constraint(
         getinner(optimizer), getindex(moirecord),
-        MOI.Interval(getcurlb(form, var), getcurub(form, var))
+        MOI.GreaterThan(getcurlb(form, var))
     )
-    setbounds!(moirecord, moi_bounds)
+    moi_upper_bound = MOI.add_constraint(
+        getinner(optimizer), getindex(moirecord),
+        MOI.LessThan(getcurub(form, var))
+    )
+    setlowerbound!(moirecord, moi_lower_bound)
+    setupperbound!(moirecord, moi_upper_bound)
     return
 end
 
@@ -174,8 +188,10 @@ function remove_from_optimizer!(::Formulation, optimizer::MoiOptimizer, var::Var
     inner = getinner(optimizer)
     moirecord = getmoirecord(var)
     @assert getindex(moirecord).value != -1
-    MOI.delete(inner, getbounds(moirecord))
-    setbounds!(moirecord, MoiVarBound())
+    MOI.delete(inner, getlowerbound(moirecord))
+    MOI.delete(inner, getupperbound(moirecord))
+    setlowerbound!(moirecord, MoiVarLowerBound())
+    setupperbound!(moirecord, MoiVarUpperBound())
     if getkind(moirecord).value != -1
         MOI.delete(inner, getkind(moirecord))
     end
@@ -200,40 +216,6 @@ function _getcolunakind(record::MoiVarRecord)
     record.kind isa MoiBinary && return Binary
     return Integ
 end
-
-function _getreducedcost(form::Formulation, optimizer, var::Variable)
-    varname = getname(form, var)
-    opt = typeof(optimizer)
-    @warn """
-        Cannot retrieve reduced cost of variable $varname from formulation solved with optimizer of type $opt. 
-        Method returns nothing.
-    """
-    return
-end
-
-function getreducedcost(form::Formulation, optimizer::MoiOptimizer, var::Variable)
-    sign = getobjsense(form) == MinSense ? 1.0 : -1.0
-    inner = getinner(optimizer)
-    if MOI.get(inner, MOI.ResultCount()) < 1
-        @warn """
-            No dual solution stored in the optimizer of formulation. Cannot retrieve reduced costs.
-            Method returns nothing.
-        """
-        return
-    end
-    if !iscuractive(form, var) || !isexplicit(form, var)
-        varname = getname(form, var)
-        @warn """
-            Cannot retrieve reduced cost of variable $varname because the variable must be active and explicit.
-            Method returns nothing.
-        """
-        return
-    end
-    bounds_interval_idx = getbounds(getmoirecord(var))
-    dualval = MOI.get(inner, MOI.ConstraintDual(1), bounds_interval_idx)
-    return sign * dualval
-end
-getreducedcost(form::Formulation, optimizer::MoiOptimizer, varid::VarId) = getreducedcost(form, optimizer, getvar(form, varid))
 
 function get_primal_solutions(form::F, optimizer::MoiOptimizer) where {F <: Formulation}
     inner = getinner(optimizer)
@@ -315,40 +297,26 @@ function get_dual_solutions(form::F, optimizer::MoiOptimizer) where {F <: Formul
         activebounds = ActiveBound[]
         for (varid, var) in getvars(form)
             moi_var_index = getindex(getmoirecord(var))
-            moi_bounds_index = getbounds(getmoirecord(var))
-            MOI.is_valid(inner, moi_var_index) && MOI.is_valid(inner, moi_bounds_index) || continue
-            basis_status = MOI.get(inner, MOI.VariableBasisStatus(res_idx), getindex(getmoirecord(var)))
-            val = MOI.get(inner, MOI.ConstraintDual(res_idx), moi_bounds_index)
-
-            # Variables with non-zero dual values have at least one active bound.
-            # Otherwise, we print a warning message.
-            if basis_status == MOI.NONBASIC_AT_LOWER
-                solcost += val * getcurlb(form, varid)
+            moi_lower_bound_index = getlowerbound(getmoirecord(var))
+            if MOI.is_valid(inner, moi_var_index) && MOI.is_valid(inner, moi_lower_bound_index)
+                val = MOI.get(inner, MOI.ConstraintDual(res_idx), moi_lower_bound_index)
                 if abs(val) > Coluna.TOL
+                    solcost += val * getcurlb(form, varid)
                     push!(varids, varid)
                     push!(varvals, sense * val)
                     push!(activebounds, LOWER)
                 end
-            elseif basis_status == MOI.NONBASIC_AT_UPPER
-                solcost += val * getcurub(form, varid)
+            end
+
+            moi_upper_bound_index = getupperbound(getmoirecord(var))
+            if MOI.is_valid(inner, moi_var_index) && MOI.is_valid(inner, moi_upper_bound_index)
+                val = MOI.get(inner, MOI.ConstraintDual(res_idx), moi_upper_bound_index)
                 if abs(val) > Coluna.TOL
+                    solcost += val * getcurub(form, varid)
                     push!(varids, varid)
                     push!(varvals, sense * val)
                     push!(activebounds, UPPER)
                 end
-            elseif basis_status == MOI.NONBASIC
-                @assert getcurlb(form, varid) == getcurlb(form, varid)
-                solcost += val * getcurub(form, varid)
-                if abs(val) > Coluna.TOL
-                    push!(varids, varid)
-                    push!(varvals, sense * val)
-                    push!(activebounds, LOWER_AND_UPPER)
-                end
-            elseif abs(val) > Coluna.TOL
-                @warn """
-                    Basis status of variable $(getname(form, varid)) that has a non-zero dual value is not treated.
-                    Basis status is $basis_status & dual value is $val.
-                """
             end
         end
         fixed_obj = 0.0

--- a/src/MathProg/MathProg.jl
+++ b/src/MathProg/MathProg.jl
@@ -91,7 +91,7 @@ export Variable, Constraint, VarId, ConstrId, VarMembership, ConstrMembership,
     getperenub, getcurub, setcurub!, getperenrhs, setperenrhs!, getcurrhs, setcurrhs!, getperensense, setperensense!,
     getcursense, setcursense!, getperenkind, getcurkind, setcurkind!, getperenincval,
     getcurincval, setcurincval!, isperenactive, iscuractive, activate!, deactivate!,
-    isexplicit, getname, getbranchingpriority, reset!, getreducedcost, setperenkind!, isfixed, fix!, unfix!,
+    isexplicit, getname, getbranchingpriority, reset!, setperenkind!, isfixed, fix!, unfix!,
     getcustomdata
 
 # Types & methods related to solutions & bounds

--- a/src/MathProg/manager.jl
+++ b/src/MathProg/manager.jl
@@ -102,16 +102,3 @@ function _addconstr!(m::FormulationManager, constr::Constraint)
     m.constrs[constr.id] = constr
     return
 end
-
-function Base.show(io::IO, m::FormulationManager)
-    println(io, "FormulationManager :")
-    println(io, "> variables : ")
-    for (id, var) in m.vars
-        println(io, "  ", id, " => ", var)
-    end
-    println(io, "> constraints : ")
-    for (id, constr) in m.constrs
-        println(io, " ", id, " => ", constr)
-    end
-    return
-end

--- a/src/MathProg/types.jl
+++ b/src/MathProg/types.jl
@@ -68,7 +68,8 @@ const MoiVarIndex = MOI.VariableIndex
 MoiVarIndex() = MOI.VariableIndex(-1)
 
 # Bounds on variables
-const MoiVarBound = MOI.ConstraintIndex{MOI.VariableIndex,MOI.Interval{Float64}}
+const MoiVarLowerBound = MOI.ConstraintIndex{MOI.VariableIndex,MOI.GreaterThan{Float64}}
+const MoiVarUpperBound = MOI.ConstraintIndex{MOI.VariableIndex,MOI.LessThan{Float64}}
 
 # Variable kinds
 const MoiInteger = MOI.ConstraintIndex{MOI.VariableIndex,MOI.Integer}

--- a/src/MathProg/variable.jl
+++ b/src/MathProg/variable.jl
@@ -35,22 +35,23 @@ Structure to hold the pointers to the MOI representation of a Coluna Variable.
 """
 mutable struct MoiVarRecord
     index::MoiVarIndex
-    bounds::MoiVarBound
-    lower_bound::Union{Nothing,Id{<:AbstractVarConstr}}
-    upper_bound::Union{Nothing,Id{<:AbstractVarConstr}}
+    lower_bound::Union{Nothing, MoiVarLowerBound}
+    upper_bound::Union{Nothing, MoiVarUpperBound}
     kind::MoiVarKind
 end
 
 function MoiVarRecord(;index::MoiVarIndex = MoiVarIndex())
-    return MoiVarRecord(index, MoiVarBound(), nothing, nothing, MoiVarKind())
+    return MoiVarRecord(index, MoiVarLowerBound(), MoiVarUpperBound(), MoiVarKind())
 end
 
 getindex(record::MoiVarRecord) = record.index
-getbounds(record::MoiVarRecord) = record.bounds
+getlowerbound(record::MoiVarRecord) = record.lower_bound
+getupperbound(record::MoiVarRecord) = record.upper_bound
 getkind(record::MoiVarRecord) = record.kind
 
 setindex!(record::MoiVarRecord, index::MoiVarIndex) = record.index = index
-setbounds!(record::MoiVarRecord, bounds::MoiVarBound) = record.bounds = bounds
+setlowerbound!(record::MoiVarRecord, bound::MoiVarLowerBound) = record.lower_bound = bound
+setupperbound!(record::MoiVarRecord, bound::MoiVarUpperBound) = record.upper_bound = bound
 setkind!(record::MoiVarRecord, kind::MoiVarKind) = record.kind = kind
 
 """

--- a/test/unit/MathProg/variables.jl
+++ b/test/unit/MathProg/variables.jl
@@ -131,13 +131,16 @@ function record()
     v_rec = ClMP.MoiVarRecord(; index = ClMP.MoiVarIndex(-15))
 
     @test ClMP.getindex(v_rec) == ClMP.MoiVarIndex(-15)
-    @test ClMP.getbounds(v_rec) == ClMP.MoiVarBound(-1)
+    @test ClMP.getlowerbound(v_rec) == ClMP.MoiVarLowerBound(-1)
+    @test ClMP.getupperbound(v_rec) == ClMP.MoiVarUpperBound(-1)
 
     ClMP.setindex!(v_rec, ClMP.MoiVarIndex(-20))
-    ClMP.setbounds!(v_rec, ClMP.MoiVarBound(10))
+    ClMP.setlowerbound!(v_rec, ClMP.MoiVarLowerBound(10))
+    ClMP.setupperbound!(v_rec, ClMP.MoiVarUpperBound(20))
 
     @test ClMP.getindex(v_rec) == ClMP.MoiVarIndex(-20)
-    @test ClMP.getbounds(v_rec) == ClMP.MoiVarBound(10)
+    @test ClMP.getlowerbound(v_rec) == ClMP.MoiVarLowerBound(10)
+    @test ClMP.getupperbound(v_rec) == ClMP.MoiVarUpperBound(20)
 end
 register!(unit_tests, "variables", record)
 


### PR DESCRIPTION
close #799 

It also removes the need for the variable basis status to get the dual multipliers of variable bound constraints.