### PR TITLE
re-organize and boost man/decomposition

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -49,7 +49,10 @@ makedocs(
             "Advanced tutorial" => joinpath("start", "advanced_demo.md"),
         ],
         "Manual" => Any[
-            "Decomposition" => joinpath("man", "decomposition.md"),
+            "Decomposition" => Any[
+                "Decomposition paradigms" => joinpath("man", "decomposition.md"),
+                "Setup decomposition using BlockDecomposition" => joinpath("man", "blockdecomposition.md")
+            ],
             "Configuration" => joinpath("man", "config.md"),
             "Built-in algorithms for Branch-and-Bound" => joinpath("man", "algorithm.md"),
             "Callbacks"   => joinpath("man", "callbacks.md"),

--- a/docs/src/man/blockdecomposition.md
+++ b/docs/src/man/blockdecomposition.md
@@ -1,0 +1,65 @@
+# Setup decomposition with BlockDecomposition
+
+BlockDecomposition allows the user to perform two types of decomposition using
+[`BlockDecomposition.@dantzig_wolfe_decomposition`](@ref) and [`BlockDecomposition.@benders_decomposition`](@ref).
+
+For both decompositions, the index-set of the subproblems is declared through an [`BlockDecomposition.@axis`](@ref). 
+It returns an array.
+Each value of the array is a subproblem index wrapped into a `BlockDecomposition.AxisId`.
+Each time BlockDecomposition finds an `AxisId` in the indices of a variable
+and a constraint, it knows to which subproblem the variable or the constraint belongs.
+
+
+The macro creates a decomposition tree where the root is the master and the depth
+is the number of nested decompositions. A classic Dantzig-Wolfe or Benders
+decomposition produces a decomposition tree of depth 1.
+At the moment, nested decomposition is not supported.
+
+You can get the subproblem membership of all variables and constraints
+using the method [`BlockDecomposition.annotation`](@ref).
+
+BlockDecomposition does not change the JuMP model.
+It decorates the model with additional information.
+All this information is stored in the `ext` field of the JuMP model.
+
+```@meta
+CurrentModule = BlockDecomposition
+```
+
+## Errors and warnings
+
+```@docs
+MasterVarInDwSp
+VarsOfSameDwSpInMaster
+```
+
+## References
+
+```@docs
+BlockModel
+```
+
+These are the methods to decompose a JuMP model :
+```@docs
+@axis
+@benders_decomposition
+@dantzig_wolfe_decomposition
+```
+
+These are the methods to set additional information to the decomposition (multiplicity and optimizers) :
+
+```@docs
+getmaster
+getsubproblems
+specify!
+```
+
+This method helps you to check your decomposition :
+
+```@docs
+annotation
+```
+
+```@meta
+CurrentModule = nothing
+```


### PR DESCRIPTION
This is an attempt to re-organise the section ```man/decomposition``` of the documentation. The files are now organized as follow:

```
Decomposition
   |_ Decomposition paradigms
          |_ Dantzig-Wolfe
          |_ Benders
   |_ Setup decomposition using BlockDecomposition
```

I also add some backup about Benders. There are some TODOs left ; we should decide if some information has to go explicitly in the doc or if we have to give some links. 