### PR TITLE
Fix the definition of the NodeFinalizer algorithm

### DIFF
--- a/src/Algorithm/conquer.jl
+++ b/src/Algorithm/conquer.jl
@@ -21,7 +21,7 @@ ParamRestrictedMasterHeuristic() =
 #                      NodeFinalizer
 ####################################################################
 
-struct NodeFinalizer
+struct NodeFinalizer <: AbstractConquerAlgorithm
     algorithm::AbstractOptimizationAlgorithm
     min_depth::Integer
     name::String


### PR DESCRIPTION
It was not defined as an AbstractAlgorithm. Why didn't the tests get this bug?