### PR TITLE
create a routine in children to check if the divide should be run

### DIFF
--- a/src/Algorithm/branching/interface.jl
+++ b/src/Algorithm/branching/interface.jl
@@ -30,15 +30,7 @@ end
 
 function run!(algo::AlgoAPI.AbstractDivideAlgorithm, env::Env, reform::Reformulation, input::Branching.AbstractDivideInput)
     ctx = new_context(branching_context_type(algo), algo, reform)
-
     conquer_opt_state = Branching.get_conquer_opt_state(input)
-    nodestatus = getterminationstatus(conquer_opt_state)
-
-    # We don't run the branching algorithm if the node is already conquered
-    if nodestatus == OPTIMAL || nodestatus == INFEASIBLE || ip_gap_closed(conquer_opt_state)             
-        # println("Node is already conquered. No children will be generated.")
-        return DivideOutput(SbNode[], conquer_opt_state)
-    end
 
     extended_sol = get_extended_sol(reform, conquer_opt_state)
     original_sol = get_original_sol(reform, conquer_opt_state)


### PR DESCRIPTION
children in ```treesearch.jl```is now responsible to decide if the divide should be run or not, depending on the divide input (obtained from the conquer output).  The checks have been moved from the run! method of divide.