### PR TITLE
Checks before conquer

### DIFF
--- a/src/Algorithm/branching/branchingalgo.jl
+++ b/src/Algorithm/branching/branchingalgo.jl
@@ -11,7 +11,6 @@ get_conquer_input_ip_primal_bound(i::ConquerInputFromSb) = get_ip_primal_bound(i
 get_conquer_input_ip_dual_bound(i::ConquerInputFromSb) = get_ip_dual_bound(i.children_candidate.optstate)
 get_node_depth(i::ConquerInputFromSb) = i.children_candidate.depth
 get_units_to_restore(i::ConquerInputFromSb) = i.children_units_to_restore
-get_run_conquer(::ConquerInputFromSb) = true
 
 ############################################################################################
 # NoBranching

--- a/src/Algorithm/conquer.jl
+++ b/src/Algorithm/conquer.jl
@@ -340,6 +340,7 @@ function run_node_finalizer!(::ColCutGenContext, node_finalizer, env, reform, no
 end
 
 function run_colcutgen_conquer!(ctx::ColCutGenContext, env, reform, input)
+    run_conquer = true # certainly useless
     # We initialize the output of the conquer algorithm using the input given by the algorithm
     # that calls the conquer strategy. This output will be updated by the conquer algorithm.
     conquer_output = OptimizationState(
@@ -348,10 +349,6 @@ function run_colcutgen_conquer!(ctx::ColCutGenContext, env, reform, input)
         ip_dual_bound = get_conquer_input_ip_dual_bound(input),
         lp_dual_bound = get_conquer_input_ip_dual_bound(input)
     )
-
-    if !get_run_conquer(input)
-        return conquer_output
-    end
 
     time_limit_reached!(conquer_output, env) && return conquer_output
 
@@ -416,10 +413,6 @@ function run!(algo::RestrMasterLPConquer, env::Env, reform::Reformulation, input
         ip_primal_bound = get_conquer_input_ip_primal_bound(input),
         ip_dual_bound = get_conquer_input_ip_dual_bound(input)
     )
-
-    if !get_run_conquer(input)
-        return conquer_output
-    end
 
     masterlp_state = run!(algo.masterlpalgo, env, getmaster(reform), conquer_output)
 

--- a/src/Algorithm/treesearch.jl
+++ b/src/Algorithm/treesearch.jl
@@ -134,6 +134,23 @@ function run_divide(divide_input)
     return !(nodestatus == OPTIMAL || nodestatus == INFEASIBLE || ip_gap_closed(conquer_opt_state))             
 end
 
+function run_conquer(space, current)
+    # TODO: improve ?
+    # Condition 1: IP Gap is closed. Abort treatment.
+    # Condition 2: in the case the conquer was already run (in strong branching),
+    # Condition 3: make sure the node has not been proven infeasible.
+    # we still need to update the node IP primal bound before exiting 
+    # (to possibly avoid branching)
+    node_state = OptimizationState(
+        getmaster(space.reformulation);
+        ip_dual_bound = current.ip_dual_bound
+    )
+    run_conquer = !ip_gap_closed(node_state, rtol = space.opt_rtol, atol = space.opt_atol)
+    run_conquer = run_conquer || !current.conquerwasrun
+    run_conquer = run_conquer && getterminationstatus(node_state) != INFEASIBLE
+    return run_conquer
+end
+
 # Implementation of the `children` method for the `AbstractColunaSearchSpace` algorithm.
 function TreeSearch.children(space::AbstractColunaSearchSpace, current::TreeSearch.AbstractNode, env, untreated_nodes)
     # restore state of the formulation for the current node.
@@ -147,7 +164,18 @@ function TreeSearch.children(space::AbstractColunaSearchSpace, current::TreeSear
     reform = get_reformulation(space)
     conquer_alg = get_conquer(space)
     conquer_input = get_input(conquer_alg, space, current)
-    conquer_output = run!(conquer_alg, env, reform, conquer_input)
+    conquer_output = nothing
+    # routine to check if the conquer should be run.
+    if run_conquer(space, current)
+        conquer_output = run!(conquer_alg, env, reform, conquer_input)
+    else
+        conquer_output = OptimizationState(
+            getmaster(reform);
+            ip_primal_bound = get_conquer_input_ip_primal_bound(input),
+            ip_dual_bound = get_conquer_input_ip_dual_bound(input),
+            lp_dual_bound = get_conquer_input_ip_dual_bound(input)
+        )
+    end
     after_conquer!(space, current, conquer_output) # callback to do some operations after the conquer.
     # built the divide input from the conquer output
     divide_alg = get_divide(space)

--- a/src/Algorithm/treesearch/branch_and_bound.jl
+++ b/src/Algorithm/treesearch/branch_and_bound.jl
@@ -57,7 +57,6 @@ end
 struct ConquerInputFromBaB <: AbstractConquerInput
     units_to_restore::UnitsUsage
     node_state::OptimizationState # Node state after its creation or its partial evaluation.
-    run_conquer::Bool
     node_depth::Int
 end
 
@@ -65,7 +64,7 @@ get_conquer_input_ip_primal_bound(i::ConquerInputFromBaB) = get_ip_primal_bound(
 get_conquer_input_ip_dual_bound(i::ConquerInputFromBaB) = get_ip_dual_bound(i.node_state)
 get_node_depth(i::ConquerInputFromBaB) = i.node_depth
 get_units_to_restore(i::ConquerInputFromBaB) = i.units_to_restore
-get_run_conquer(i::ConquerInputFromBaB) = i.run_conquer
+
 
 ############################################################################################
 # AbstractDivideInput implementation for the branch & bound.
@@ -213,20 +212,9 @@ function get_input(::AbstractConquerAlgorithm, space::BaBSearchSpace, current::N
         update_ip_primal_bound!(node_state, space_primal_bound)
     end
 
-    # TODO: improve ?
-    # Condition 1: IP Gap is closed. Abort treatment.
-    # Condition 2: in the case the conquer was already run (in strong branching),
-    # Condition 3: make sure the node has not been proven infeasible.
-    # we still need to update the node IP primal bound before exiting 
-    # (to possibly avoid branching)
-    run_conquer = !ip_gap_closed(node_state, rtol = space.opt_rtol, atol = space.opt_atol)
-    run_conquer = run_conquer || !current.conquerwasrun
-    run_conquer = run_conquer && getterminationstatus(node_state) != INFEASIBLE
-
     return ConquerInputFromBaB(
         space.conquer_units_to_restore, 
         node_state,
-        run_conquer,
         current.depth
     )
 end


### PR DESCRIPTION
I created a routine run_conquer in ```treesearch.jl```responsible to perform checks before eventually calling the run! of conquer. This allowed to remove the boolean run_conquer from the conquer input.