### PR TITLE
create subroutine gap_closed in bounds.jl

### DIFF
--- a/src/MathProg/bounds.jl
+++ b/src/MathProg/bounds.jl
@@ -86,6 +86,7 @@ function ObjValues(
     return ov
 end
 
+
 ## Gaps
 _ip_gap(ov::ObjValues) = gap(ov.ip_primal_bound, ov.ip_dual_bound)
 _lp_gap(ov::ObjValues) = gap(ov.lp_primal_bound, ov.lp_dual_bound)
@@ -93,10 +94,17 @@ _lp_gap(ov::ObjValues) = gap(ov.lp_primal_bound, ov.lp_dual_bound)
 function _ip_gap_closed(
     ov::ObjValues; atol = Coluna.DEF_OPTIMALITY_ATOL, rtol = Coluna.DEF_OPTIMALITY_RTOL
 )
-    return _ip_gap(ov) <= 0 || _gap_closed(
-        ov.ip_primal_bound.value, ov.ip_dual_bound.value, atol = atol, rtol = rtol
+    return gap_closed(ov.ip_primal_bound, ov.ip_dual_bound; atol, rtol)
+end
+
+function gap_closed(
+    pb::Bound, db::Bound; atol = Coluna.DEF_OPTIMALITY_ATOL, rtol = Coluna.DEF_OPTIMALITY_RTOL
+)
+    return gap(pb, db) <= 0 || _gap_closed(
+        pb.value, db.value, atol = atol, rtol = rtol
     )
 end
+
 
 function _lp_gap_closed(
     ov::ObjValues; atol = Coluna.DEF_OPTIMALITY_ATOL, rtol = Coluna.DEF_OPTIMALITY_RTOL

--- a/src/MathProg/bounds.jl
+++ b/src/MathProg/bounds.jl
@@ -91,12 +91,6 @@ end
 _ip_gap(ov::ObjValues) = gap(ov.ip_primal_bound, ov.ip_dual_bound)
 _lp_gap(ov::ObjValues) = gap(ov.lp_primal_bound, ov.lp_dual_bound)
 
-function _ip_gap_closed(
-    ov::ObjValues; atol = Coluna.DEF_OPTIMALITY_ATOL, rtol = Coluna.DEF_OPTIMALITY_RTOL
-)
-    return gap_closed(ov.ip_primal_bound, ov.ip_dual_bound; atol, rtol)
-end
-
 function gap_closed(
     pb::Bound, db::Bound; atol = Coluna.DEF_OPTIMALITY_ATOL, rtol = Coluna.DEF_OPTIMALITY_RTOL
 )
@@ -106,12 +100,17 @@ function gap_closed(
 end
 
 
+function _ip_gap_closed(
+    ov::ObjValues; atol = Coluna.DEF_OPTIMALITY_ATOL, rtol = Coluna.DEF_OPTIMALITY_RTOL
+)
+    return gap_closed(ov.ip_primal_bound, ov.ip_dual_bound; atol, rtol)
+end
+
+
 function _lp_gap_closed(
     ov::ObjValues; atol = Coluna.DEF_OPTIMALITY_ATOL, rtol = Coluna.DEF_OPTIMALITY_RTOL
 )
-    return _lp_gap(ov) <= 0 || _gap_closed(
-       ov.lp_primal_bound.value, ov.lp_dual_bound.value, atol = atol, rtol = rtol
-    )
+    return gap_closed(ov.lp_primal_bound, ov.lp_dual_bound; atol, rtol)
 end
 
 function _gap_closed(


### PR DESCRIPTION
We create a subroutine `gap_closed` that takes as two bounds as arguments  instead of an optimization state (as in `_ip_gap_closed`). ```_ip_gap_closed``` calls this subroutine now.  