### PR TITLE
Fix the primal and dual bounds set by the node finalizer

### DIFF
--- a/src/Algorithm/conquer.jl
+++ b/src/Algorithm/conquer.jl
@@ -308,6 +308,7 @@ function run_node_finalizer!(::ColCutGenContext, node_finalizer, env, reform, no
 
             # make sure that the gap is closed for the current node
             dual_bound = DualBound(reform, getvalue(get_ip_primal_bound(conquer_output)))
+            update_lp_dual_bound!(conquer_output, dual_bound)
             update_ip_dual_bound!(conquer_output, dual_bound)
         else
             if !isnothing(ip_primal_sols) && length(ip_primal_sols) > 0

--- a/src/Algorithm/treesearch/branch_and_bound.jl
+++ b/src/Algorithm/treesearch/branch_and_bound.jl
@@ -211,6 +211,9 @@ end
 function after_conquer!(space::BaBSearchSpace, current, conquer_output)
     @assert !isnothing(conquer_output)
     treestate = space.optstate
+    for sol in get_ip_primal_sols(conquer_output)
+        store_ip_primal_sol!(space.inc_primal_manager, sol)
+    end
     current.records = create_records(space.reformulation)
     current.conquerwasrun = true
     space.nb_nodes_treated += 1

--- a/test/e2e_extra/advanced_colgen/node_finalizer_tests.jl
+++ b/test/e2e_extra/advanced_colgen/node_finalizer_tests.jl
@@ -143,11 +143,7 @@ function test_node_finalizer(heuristic_finalizer)
 
     JuMP.optimize!(model)
     @show JuMP.objective_value(model)
-    if heuristic_finalizer
-        @test JuMP.termination_status(model) == MOI.OPTIMAL
-    else
-        @test JuMP.termination_status(model) == MOI.OTHER_LIMIT
-    end
+    @test JuMP.termination_status(model) == MOI.OPTIMAL
     for b in B
         sets = BD.getsolutions(model, b)
         for s in sets


### PR DESCRIPTION
Note that the test was changed to expect "optimal" as the solution status. For that, the node finalizer needed to set also the LP dual bound in the exact mode. This makes more sense as the node should be considered as conquered in the exact mode.