### PR TITLE
Build Reformulation after Formulations

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,6 @@ version = "0.6.5"
 
 [deps]
 BlockDecomposition = "6cde8614-403a-11e9-12f1-c10d0f0caca0"
-ColunaDemos = "a54e61d4-7723-11e9-2469-af255fcaa246"
 Crayons = "a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/MathProg/reformulation.jl
+++ b/src/MathProg/reformulation.jl
@@ -1,10 +1,10 @@
 # TODO make immutable
-mutable struct Reformulation <: AbstractFormulation
+mutable struct Reformulation{MasterDuty} <: AbstractFormulation
     uid::Int
-    parent::Union{Nothing, AbstractFormulation} # reference to (pointer to) ancestor:  Formulation or Reformulation (TODO rm Nothing)
-    master::Union{Nothing, Formulation}  # TODO : rm Nothing
-    dw_pricing_subprs::Dict{FormId, AbstractModel} 
-    benders_sep_subprs::Dict{FormId, AbstractModel}
+    parent::Formulation{Original} # reference to (pointer to) ancestor:  Formulation or Reformulation (TODO rm Nothing)
+    master::Formulation{MasterDuty}
+    dw_pricing_subprs::Dict{FormId, Formulation{DwSp}} 
+    benders_sep_subprs::Dict{FormId, Formulation{BendersSp}}
     storage::Union{Nothing,Storage}
 end
 
@@ -22,8 +22,22 @@ function Reformulation(env)
         uid,
         nothing,
         nothing,
-        Dict{FormId, AbstractModel}(),
-        Dict{FormId, AbstractModel}(),
+        Dict{FormId, Formulation{DwSp}}(),
+        Dict{FormId, Formulation{BendersSp}}(),
+        nothing
+    )
+    reform.storage = Storage(reform)
+    return reform
+end
+
+function Reformulation(env, parent, master, dw_pricing_subprs, benders_sep_subprs)
+    uid = env.form_counter += 1
+    reform = Reformulation(
+        uid,
+        parent,
+        master,
+        dw_pricing_subprs,
+        benders_sep_subprs,
         nothing
     )
     reform.storage = Storage(reform)

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -549,10 +549,6 @@ module Parser
             closefillmode!(ClMP.getcoefmatrix(sp))
         end
         closefillmode!(ClMP.getcoefmatrix(master))
-
-        @show master
-
-        @show subproblems
         return env, master, subproblems, constraints, reform
     end
 
@@ -602,7 +598,6 @@ module Parser
         end
 
         env, master, subproblems, constraints, reform = reformfromcache(cache)
-
         return env, master, subproblems, constraints, reform
     end
     export reformfromstring

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -298,10 +298,10 @@ module Parser
 
     read_variables!(::Any, ::Any, ::ReadCache, ::AbstractString) = nothing
 
-    function create_subproblems!(::Val{:subproblem}, env::Env{ClMP.VarId}, reform::ClMP.Reformulation, cache::ReadCache, ::Nothing)
+    function create_subproblems!(::Val{:subproblem}, env::Env{ClMP.VarId}, cache::ReadCache, ::Nothing)
         i = 1
         constraints = ClMP.Constraint[]
-        subproblems = []
+        subproblems = ClMP.Formulation{ClMP.DwSp}[]
         all_spvars = Dict{String, Tuple{ClMP.Variable, ClMP.Formulation{ClMP.DwSp}}}()
         for (_, sp) in cache.subproblems
             spform = nothing
@@ -338,17 +338,16 @@ module Parser
                 i += 1
             end
             push!(subproblems, spform)
-            ClMP.add_dw_pricing_sp!(reform, spform)
         end
         return subproblems, all_spvars, constraints
     end
 
-    function create_subproblems!(::Val{:separation}, env::Env{ClMP.VarId}, reform::ClMP.Reformulation, cache::ReadCache, master, mastervars)
+    function create_subproblems!(::Val{:separation}, env::Env{ClMP.VarId}, cache::ReadCache, master, mastervars)
         i = 1
         constraints = ClMP.Constraint[]
-        subproblems = []
+        subproblems = ClMP.Formulation{ClMP.BendersSp}[]
         all_spvars = Dict{String, Tuple{ClMP.Variable, ClMP.Formulation{ClMP.BendersSp}}}()
-        for (_, sp) in cache.subproblems
+        for (_, sp) in cache.subproblems 
             spform = ClMP.create_formulation!(
                 env,
                 ClMP.BendersSp();
@@ -396,7 +395,6 @@ module Parser
                 i += 1
             end
             push!(subproblems, spform)
-            ClMP.add_benders_sep_sp!(reform, spform)
         end
         return subproblems, all_spvars, constraints
     end
@@ -408,7 +406,9 @@ module Parser
                 var = cache.variables[varid]
                 if var.duty <= ClMP.AbstractOriginMasterVar || var.duty <= ClMP.AbstractAddedMasterVar
                     is_explicit = !(var.duty <= ClMP.AbstractImplicitMasterVar)
+                    @show varid
                     v = ClMP.setvar!(master, varid, var.duty; lb = var.lb, ub = var.ub, kind = var.kind, is_explicit = is_explicit)
+                    @show ClMP.getid(v)
                 else
                     if haskey(all_spvars, varid)
                         var, sp = all_spvars[varid]
@@ -421,6 +421,8 @@ module Parser
                             explicit = true
                         end
                         v = ClMP.clonevar!(sp, master, sp, var, duty; cost = ClMP.getcurcost(sp, var), is_explicit = explicit)
+                        @show ClMP.getname(master, v)
+                        @show ClMP.getid(v)
                     else
                         throw(UndefVarParserError("Variable $varid not present in any subproblem"))
                     end
@@ -449,7 +451,7 @@ module Parser
         return mastervars
     end
 
-    function add_master_constraints!(reform, master::ClMP.Formulation, mastervars::Dict{String, ClMP.Variable}, constraints::Vector{ClMP.Constraint}, cache::ReadCache)
+    function add_master_constraints!(subproblems, master::ClMP.Formulation, mastervars::Dict{String, ClMP.Variable}, constraints::Vector{ClMP.Constraint}, cache::ReadCache)
         #create master constraints
         i = 1
         for constr in cache.master.constraints
@@ -476,7 +478,7 @@ module Parser
             c = ClMP.setconstr!(master, "c$i", constr_duty; rhs = constr.rhs, sense = constr.sense, members = members)
             if constr_duty <= ClMP.MasterConvexityConstr
                 setup_var_id = collect(keys(filter(x -> ClMP.getduty(x[1]) <= ClMP.MasterRepPricingSetupVar, members)))[1]
-                spform = collect(values(filter(sp -> haskey(sp[2], setup_var_id), ClMP.get_dw_pricing_sps(reform))))[1]
+                spform = collect(values(filter(sp -> haskey(sp, setup_var_id), subproblems)))[1] # dw pricing sps
                 if constr.sense == ClMP.Less
                     spform.duty_data.upper_multiplicity_constr_id = ClMP.getid(c)
                 elseif constr.sense == ClMP.Greater
@@ -498,35 +500,48 @@ module Parser
             throw(UndefVarParserError("No variable duty and kind defined"))
         end
         env = Env{ClMP.VarId}(CL.Params())
-        reform = ClMP.Reformulation(env)
 
         dec = cache.benders_sp_type ? Val(:separation) : Val(:subproblem)
         master_duty = cache.benders_sp_type ? ClMP.BendersMaster() : ClMP.DwMaster()
 
+        dw_sps = Dict{ClMP.FormId, ClMP.Formulation{ClMP.DwSp}}()
+        benders_sps = Dict{ClMP.FormId, ClMP.Formulation{ClMP.BendersSp}}()
+
+        origform = ClMP.create_formulation!(
+            env,
+            ClMP.Original();
+            obj_sense = cache.master.sense,
+        )
+
+        # Create master first.
+        master =  ClMP.create_formulation!(
+            env,
+            master_duty;
+            obj_sense = cache.master.sense,
+        )
+        # ugly trick here.
+        dw_sps = Dict{ClMP.FormId, ClMP.Formulation{ClMP.DwSp}}()
+        benders_sps = Dict{ClMP.FormId, ClMP.Formulation{ClMP.BendersSp}}()
+        reform = ClMP.Reformulation(env, origform, master, dw_sps, benders_sps)
+        master.parent_formulation = reform
+    
+        # Populate master & create subproblems then.
         if cache.benders_sp_type
-            master = ClMP.create_formulation!(
-                env,
-                master_duty;
-                obj_sense = cache.master.sense,
-                parent_formulation = reform
-            )
-            ClMP.setmaster!(reform, master)
             mastervars = add_bend_master_vars!(master, master_duty, cache)
             ClMP.setobjconst!(master, cache.master.objective.constant)
-            subproblems, all_spvars, constraints = create_subproblems!(dec, env, reform, cache, master, mastervars)
-            add_master_constraints!(reform, master, mastervars, constraints, cache)
+            subproblems, all_spvars, constraints = create_subproblems!(dec, env, cache, master, mastervars)
+            for sp in subproblems
+                reform.benders_sep_subprs[ClMP.getuid(sp)] = sp
+            end
+            add_master_constraints!(subproblems, master, mastervars, constraints, cache)
         else
-            subproblems, all_spvars, constraints = create_subproblems!(dec, env, reform, cache, nothing)
-            master = ClMP.create_formulation!(
-                env,
-                master_duty;
-                obj_sense = cache.master.sense,
-                parent_formulation = reform
-            )
-            ClMP.setmaster!(reform, master)
+            subproblems, all_spvars, constraints = create_subproblems!(dec, env, cache, nothing)
+            for sp in subproblems
+                reform.dw_pricing_subprs[ClMP.getuid(sp)] = sp
+            end
             mastervars = add_dw_master_vars!(master, master_duty, all_spvars, cache)
             ClMP.setobjconst!(master, cache.master.objective.constant)
-            add_master_constraints!(reform, master, mastervars, constraints, cache)
+            add_master_constraints!(subproblems, master, mastervars, constraints, cache)
         end
 
         for sp in subproblems
@@ -535,6 +550,9 @@ module Parser
         end
         closefillmode!(ClMP.getcoefmatrix(master))
 
+        @show master
+
+        @show subproblems
         return env, master, subproblems, constraints, reform
     end
 

--- a/test/unit/Benders/benders_cuts.jl
+++ b/test/unit/Benders/benders_cuts.jl
@@ -113,8 +113,8 @@ end
 function test_benders_cut_lhs()
     _, reform = benders_form_D()
     master = Coluna.MathProg.getmaster(reform)
-    sps = Coluna.MathProg.get_benders_sep_sps(reform) ##one sp, spid = 3
-    sp = sps[3]
+    sps = Coluna.MathProg.get_benders_sep_sps(reform) ##one sp, spid = 4
+    sp = sps[4]
     cids = get_name_to_constrids(sp)
     vids = get_name_to_varsids(sp)
     alg = Coluna.Algorithm.BendersCutGeneration(
@@ -151,8 +151,8 @@ function test_benders_cut_rhs()
 
     _, reform = benders_form_D()
     master = Coluna.MathProg.getmaster(reform)
-    sps = Coluna.MathProg.get_benders_sep_sps(reform) ##one sp, spid = 3
-    sp = sps[3]
+    sps = Coluna.MathProg.get_benders_sep_sps(reform) ##one sp, spid = 4
+    sp = sps[4]
     cids = get_name_to_constrids(sp)
     vids = get_name_to_varsids(sp)
     alg = Coluna.Algorithm.BendersCutGeneration(

--- a/test/unit/Benders/benders_default.jl
+++ b/test/unit/Benders/benders_default.jl
@@ -1157,7 +1157,7 @@ function test_two_identicals_cut_at_two_iterations_failure()
     env, reform = benders_form_A()
     master = ClMP.getmaster(reform)
     sps = ClMP.get_benders_sep_sps(reform)
-    spform = sps[3]
+    spform = sps[4]
     spconstrids = Dict(CL.getname(spform, constr) => constrid for (constrid, constr) in CL.getconstrs(spform))
     spvarids = Dict(CL.getname(spform, var) => varid for (varid, var) in CL.getvars(spform))
 

--- a/test/unit/Branching/branching_default.jl
+++ b/test/unit/Branching/branching_default.jl
@@ -130,14 +130,14 @@ function test_strong_branching()
     extended_sol = Coluna.PrimalSolution(
         master,
         [
-            _id(vars["MC_36"], 3),
-            _id(vars["MC_38"], 3),
-            _id(vars["MC_39"], 2),
-            _id(vars["MC_42"], 3),
-            _id(vars["MC_43"], 2),
-            _id(vars["MC_44"], 3),
-            _id(vars["MC_46"], 3),
-            _id(vars["MC_47"], 2)
+            _id(vars["MC_36"], 4),
+            _id(vars["MC_38"], 4),
+            _id(vars["MC_39"], 5),
+            _id(vars["MC_42"], 4),
+            _id(vars["MC_43"], 5),
+            _id(vars["MC_44"], 4),
+            _id(vars["MC_46"], 4),
+            _id(vars["MC_47"], 5)
         ],
         [0.5, 0.16666667, 0.16666667, 0.33333333, 0.16666667, 0.16666667, 0.33333333, 0.16666667],
         31.5,

--- a/test/unit/MathProg/benders_decomposition.jl
+++ b/test/unit/MathProg/benders_decomposition.jl
@@ -85,11 +85,11 @@ function benders_decomposition()
     reform = Coluna.MathProg.get_reformulation(problem)
 
     # Test first stage variables & constraints
-    # Coluna.MathProg.MinSense + 1.0 x1 + 4.0 x2 + 1.0 η[5]  
+    # Coluna.MathProg.MinSense + 1.0 x1 + 4.0 x2 + 1.0 η[4]  
     # c3 : + 1.0 x1 + 1.0 x2  >= 0.0 (MasterPureConstrConstraintu3 | true)
     # 0.0 <= x1 <= Inf (Continuous | MasterPureVar | true)
     # 0.0 <= x2 <= Inf (Continuous | MasterPureVar | true)
-    # 0.0 <= η[5] <= Inf (Continuous | MasterBendSecondStageCostVar | true)
+    # 0.0 <= η[4] <= Inf (Continuous | MasterBendSecondStageCostVar | true)
 
     master = Coluna.MathProg.getmaster(reform)
     fs_vars = Dict(getname(master, varid) => var for (varid, var) in Coluna.MathProg.getvars(master))
@@ -99,19 +99,19 @@ function benders_decomposition()
 
     @test Coluna.MathProg.getduty(Coluna.MathProg.getid(fs_vars["x1"])) <= Coluna.MathProg.MasterPureVar
     @test Coluna.MathProg.getduty(Coluna.MathProg.getid(fs_vars["x2"])) <= Coluna.MathProg.MasterPureVar
-    @test Coluna.MathProg.getduty(Coluna.MathProg.getid(fs_vars["η[5]"])) <= Coluna.MathProg.MasterBendSecondStageCostVar
+    @test Coluna.MathProg.getduty(Coluna.MathProg.getid(fs_vars["η[4]"])) <= Coluna.MathProg.MasterBendSecondStageCostVar
 
     @test Coluna.MathProg.getcurlb(master, fs_vars["x1"]) == 0.0
     @test Coluna.MathProg.getcurlb(master, fs_vars["x2"]) == 0.0
-    @test Coluna.MathProg.getcurlb(master, fs_vars["η[5]"]) == -Inf
+    @test Coluna.MathProg.getcurlb(master, fs_vars["η[4]"]) == -Inf
 
     @test Coluna.MathProg.getcurub(master, fs_vars["x1"]) == Inf
     @test Coluna.MathProg.getcurub(master, fs_vars["x2"]) == Inf
-    @test Coluna.MathProg.getcurub(master, fs_vars["η[5]"]) == Inf
+    @test Coluna.MathProg.getcurub(master, fs_vars["η[4]"]) == Inf
 
     @test Coluna.MathProg.getcurcost(master, fs_vars["x1"]) == 1.0
     @test Coluna.MathProg.getcurcost(master, fs_vars["x2"]) == 4.0
-    @test Coluna.MathProg.getcurcost(master, fs_vars["η[5]"]) == 1.0
+    @test Coluna.MathProg.getcurcost(master, fs_vars["η[4]"]) == 1.0
 
     @test length(fs_constrs) == 1
 

--- a/test/unit/MathProg/projection.jl
+++ b/test/unit/MathProg/projection.jl
@@ -168,7 +168,7 @@ function projection_from_dw_reform_to_master_1()
     # This solution is integer feasible.
     solution = Coluna.MathProg.PrimalSolution(
         master,
-        map(n -> ClMP.VarId(mastervarids[n]; origin_form_uid = 2), ["MC1", "MC2", "MC3", "MC4"]),
+        map(n -> ClMP.VarId(mastervarids[n]; origin_form_uid = 4), ["MC1", "MC2", "MC3", "MC4"]),
         [1/2, 1/2, 1/2, 1/2],
         2.0,
         ClB.FEASIBLE_SOL
@@ -185,7 +185,8 @@ function projection_from_dw_reform_to_master_1()
     # | 1/2 of [0.0, 0.0, 1.0, 0.0, 0.0, 1.0]
     # | 1/2 of [0.0, 0.0, 0.0, 1.0, 0.0, 1.0]
     # ----->   [0.0, 0.0, 0.5, 0.5, 0.0, 1.0]
-    @test rolls == Dict(2 => [
+
+    @test rolls == Dict( 4 => [
         Dict(mastervarids["x_14"] => 0.5, mastervarids["x_23"] => 0.5, mastervarids["x_34"] => 1.0)
         Dict(mastervarids["x_12"] => 1.0, mastervarids["x_14"] => 0.5, mastervarids["x_23"] => 0.5)
     ])


### PR DESCRIPTION
Tests depend a lot on hard-coded formulation ids. It makes maintenance difficult.