### PR TITLE
Remove children nodes from branching candidates

### DIFF
--- a/docs/src/api/branching.md
+++ b/docs/src/api/branching.md
@@ -49,9 +49,6 @@ Branching.AbstractBranchingCandidate
 Branching.getdescription
 Branching.get_lhs
 Branching.get_local_id
-Branching.get_children
-Branching.set_children!
-Branching.get_parent
 Branching.generate_children!
 ```
 

--- a/src/Algorithm/branching/printer.jl
+++ b/src/Algorithm/branching/printer.jl
@@ -31,13 +31,13 @@ function new_phase_context(
     return PhasePrinter(inner_ctx, phase_index)
 end
 
-function Branching.perform_branching_phase!(candidates, phase::PhasePrinter, sb_state, env, reform, input)
+function Branching.perform_branching_phase!(candidates, cand_children, phase::PhasePrinter, sb_state, env, reform, input)
     println("**** Strong branching phase ", phase.phase_index, " is started *****");
-    scores = Branching.perform_branching_phase_inner!(candidates, phase, sb_state, env, reform, input)
-    for (candidate, score) in Iterators.zip(candidates, scores)
+    scores = Branching.perform_branching_phase_inner!(cand_children, phase, sb_state, env, reform, input)
+    for (candidate, children, score) in Iterators.zip(candidates, cand_children, scores)
         @printf "SB phase %i branch on %+10s" phase.phase_index  Branching.getdescription(candidate)
         @printf " (lhs=%.4f) : [" Branching.get_lhs(candidate)
-        for (node_index, node) in enumerate(Branching.get_children(candidate))
+        for (node_index, node) in enumerate(children)
             node_index > 1 && print(",")            
             @printf "%10.4f" getvalue(get_lp_primal_bound(node.optstate))
         end

--- a/src/Algorithm/branching/scores.jl
+++ b/src/Algorithm/branching/scores.jl
@@ -1,20 +1,19 @@
 struct ProductScore <: Branching.AbstractBranchingScore end
 
-function Branching.compute_score(::ProductScore, candidate, input)
+function Branching.compute_score(::ProductScore, children, input)
     parent = Branching.get_conquer_opt_state(input)
     parent_lp_dual_bound = get_lp_dual_bound(parent)
     parent_ip_primal_bound = get_ip_primal_bound(parent)
-    children_lp_primal_bounds = get_lp_primal_bound.(getfield.(Branching.get_children(candidate), Ref(:optstate)))
+    children_lp_primal_bounds = get_lp_primal_bound.(getfield.(children, Ref(:optstate)))
     return _product_score(parent_lp_dual_bound, parent_ip_primal_bound, children_lp_primal_bounds)
 end
 
 struct TreeDepthScore <: Branching.AbstractBranchingScore end
 
-function Branching.compute_score(::TreeDepthScore, candidate, input)
+function Branching.compute_score(::TreeDepthScore, children, input)
     parent = Branching.get_conquer_opt_state(input)
     parent_lp_dual_bound = get_lp_dual_bound(parent)
     parent_ip_primal_bound = get_ip_primal_bound(parent)
-    children = Branching.get_children(candidate)
     children_lp_primal_bounds = get_lp_primal_bound.(getfield.(children, :optstate))
     return _tree_depth_score(parent_lp_dual_bound, parent_ip_primal_bound, children_lp_primal_bounds)
 end

--- a/src/Algorithm/branching/single_var_branching.jl
+++ b/src/Algorithm/branching/single_var_branching.jl
@@ -13,21 +13,16 @@ mutable struct SingleVarBranchingCandidate <: Branching.AbstractBranchingCandida
     varid::VarId
     local_id::Int64
     lhs::Float64
-    score::Float64
-    children::Vector{SbNode}
-    isconquered::Bool
     function SingleVarBranchingCandidate(
         varname::String, varid::VarId, local_id::Int64, lhs::Float64
     )
-        return new(varname, varid, local_id, lhs, 0.0, SbNode[], false)
+        return new(varname, varid, local_id, lhs)
     end
 end
 
 Branching.getdescription(candidate::SingleVarBranchingCandidate) = candidate.varname
 Branching.get_lhs(candidate::SingleVarBranchingCandidate) = candidate.lhs
 Branching.get_local_id(candidate::SingleVarBranchingCandidate) = candidate.local_id
-Branching.get_children(candidate::SingleVarBranchingCandidate) = candidate.children
-Branching.set_children!(candidate::SingleVarBranchingCandidate, children) = candidate.children = children
 
 function get_branching_candidate_units_usage(::SingleVarBranchingCandidate, reform)
     units_to_restore = UnitsUsage()

--- a/src/Branching/candidate.jl
+++ b/src/Branching/candidate.jl
@@ -23,24 +23,10 @@ abstract type AbstractBranchingCandidate end
 "Returns the generation id of the candidiate."
 @mustimplement "BranchingCandidate" get_local_id(c::AbstractBranchingCandidate) = nothing
 
-"Returns the children of the candidate."
-@mustimplement "BranchingCandidate" get_children(c::AbstractBranchingCandidate) = nothing
-
-"Set the children of the candidate."
-@mustimplement "BranchingCandidate" set_children!(c::AbstractBranchingCandidate, children) = nothing
-
-"Returns the parent node of the candidate's children."
-@mustimplement "BranchingCandidate" get_parent(c::AbstractBranchingCandidate) = nothing
-
-# TODO: this method should not generate the children of the tree search algorithm.
-# However, AbstractBranchingCandidate should implement an interface to retrieve data to
-# generate a children.
 """
     generate_children!(branching_candidate, lhs, env, reform, node)
 
 This method generates the children of a node described by `branching_candidate`.
-Make sure that this method returns an object the same type as the second argument of
-`set_children!(candiate, children)`.
 """
 @mustimplement "BranchingCandidate" generate_children!(c::AbstractBranchingCandidate, env, reform, parent) = nothing
 


### PR DESCRIPTION
Generating child nodes from branching candidates is moved from `select!()` to `advanced_select!()`. This allows us to simplify the interface of branching candidates (we remove nodes from them). This simplification also serves to prepare the diving implementation.