### PR TITLE
Correction for output of the global dual bound

### DIFF
--- a/src/Algorithm/treesearch.jl
+++ b/src/Algorithm/treesearch.jl
@@ -122,7 +122,7 @@ The input can be built from information contained in a search space and a node.
 Methods to perform operations before the tree search algorithm evaluates a node (`current`).
 This is useful to restore the state of the formulation for instance.
 """
-@mustimplement "ColunaSearchSpace" node_change!(previous::TreeSearch.AbstractNode, current::TreeSearch.AbstractNode, space::AbstractColunaSearchSpace, untreated_nodes) = nothing
+@mustimplement "ColunaSearchSpace" node_change!(previous::TreeSearch.AbstractNode, current::TreeSearch.AbstractNode, space::AbstractColunaSearchSpace) = nothing
 
 """
 Methods to perform operations after the conquer algorithms.
@@ -151,11 +151,11 @@ Performs operations after the divide algorithm when the current node is finally 
 @mustimplement "ColunaSearchSpace" node_is_pruned(sp::AbstractColunaSearchSpace, current) = nothing
 
 # Implementation of the `children` method for the `AbstractColunaSearchSpace` algorithm.
-function TreeSearch.children(space::AbstractColunaSearchSpace, current::TreeSearch.AbstractNode, env, untreated_nodes)
+function TreeSearch.children(space::AbstractColunaSearchSpace, current::TreeSearch.AbstractNode, env)
     # restore state of the formulation for the current node.
     previous = get_previous(space)
     if !isnothing(previous)
-        node_change!(previous, current, space, untreated_nodes)
+        node_change!(previous, current, space)
     end
     set_previous!(space, current)
     # We should avoid the whole exploration of a node if its local dual bound inherited from its parent is worst than a primal bound found elsewhere on the tree. 

--- a/src/Algorithm/treesearch/printer.jl
+++ b/src/Algorithm/treesearch/printer.jl
@@ -53,9 +53,9 @@ end
 
 TreeSearch.get_priority(explore::TreeSearch.AbstractExploreStrategy, n::PrintedNode) = TreeSearch.get_priority(explore, n.inner)
 
-function TreeSearch.tree_search_output(sp::PrinterSearchSpace, untreated_nodes)
+function TreeSearch.tree_search_output(sp::PrinterSearchSpace)
     close_tree_search_file!(sp.file_printer)
-    return TreeSearch.tree_search_output(sp.inner, Iterators.map(n -> n.inner, untreated_nodes))
+    return TreeSearch.tree_search_output(sp.inner)
 end
 
 function TreeSearch.new_space(
@@ -83,9 +83,9 @@ end
 _inner_node(n::PrintedNode) = n.inner # `untreated_node` is a stack.
 _inner_node(n::Pair{<:PrintedNode, Float64}) = first(n).inner # `untreated_node` is a priority queue.
 
-function TreeSearch.children(sp::PrinterSearchSpace, current, env, untreated_nodes)
-    print_log(sp.log_printer, sp, current, env, length(untreated_nodes))
-    children =  TreeSearch.children(sp.inner, current.inner, env, Iterators.map(_inner_node, untreated_nodes))
+function TreeSearch.children(sp::PrinterSearchSpace, current, env)
+    print_log(sp.log_printer, sp, current, env, sp.inner.nb_untreated_nodes)
+    children =  TreeSearch.children(sp.inner, current.inner, env)
     # We print node information in the file after the node has been evaluated.
     print_node_in_tree_search_file!(sp.file_printer, current, sp, env)
     return map(children) do child
@@ -93,7 +93,9 @@ function TreeSearch.children(sp::PrinterSearchSpace, current, env, untreated_nod
     end
 end
 
-TreeSearch.stop(sp::PrinterSearchSpace, untreated_nodes) = TreeSearch.stop(sp.inner, untreated_nodes)
+function TreeSearch.stop(sp::PrinterSearchSpace, untreated_nodes) 
+    return TreeSearch.stop(sp.inner, Iterators.map(_inner_node, untreated_nodes))
+end
 
 ############################################################################################
 # Default file printers.

--- a/src/TreeSearch/TreeSearch.jl
+++ b/src/TreeSearch/TreeSearch.jl
@@ -52,16 +52,14 @@ get_conquer_output(::AbstractNode) = nothing
 "Returns `true` is the node is root; `false` otherwise."
 @mustimplement "Node" isroot(::AbstractNode) = nothing # BaB implementation
 
-# TODO: remove untreated nodes.
 "Evaluate and generate children. This method has a specific implementation for Coluna."
-@mustimplement "TreeSearch" children(sp, n, env, untreated_nodes) = nothing
+@mustimplement "TreeSearch" children(sp, n, env) = nothing
 
 "Returns true if stopping criteria are met; false otherwise."
 @mustimplement "TreeSearch" stop(::AbstractSearchSpace, untreated_nodes) = nothing
 
-# TODO: remove untreated nodes.
 "Returns the output of the tree search algorithm."
-@mustimplement "TreeSearch" tree_search_output(::AbstractSearchSpace, untreated_nodes) = nothing
+@mustimplement "TreeSearch" tree_search_output(::AbstractSearchSpace) = nothing
 
 # Default implementations for some explore strategies.
 include("explore.jl")

--- a/src/TreeSearch/explore.jl
+++ b/src/TreeSearch/explore.jl
@@ -19,24 +19,26 @@ function tree_search(::DepthFirstStrategy, space, env, input)
     root_node = new_root(space, input)
     stack = Stack{typeof(root_node)}()
     push!(stack, root_node)
-    while !isempty(stack) && !stop(space, stack)
+    # it is important to call `stop()` function first, as it may update `space`
+    while !stop(space, stack) && !isempty(stack)
         current = pop!(stack)
-        for child in children(space, current, env, stack)
+        for child in children(space, current, env)
             push!(stack, child)
         end
     end
-    return TreeSearch.tree_search_output(space, stack)
+    return TreeSearch.tree_search_output(space)
 end
 
 function tree_search(strategy::AbstractBestFirstSearch, space, env, input)
     root_node = new_root(space, input)
     pq = PriorityQueue{typeof(root_node), Float64}()
     enqueue!(pq, root_node, get_priority(strategy, root_node))
-    while !isempty(pq) && !stop(space, pq)
+    # it is important to call `stop()` function first, as it may update `space`
+    while !stop(space, pq) && !isempty(pq)
         current = dequeue!(pq)
-        for child in children(space, current, env, pq)
+        for child in children(space, current, env)
             enqueue!(pq, child, get_priority(strategy, child))
         end
     end
-    return TreeSearch.tree_search_output(space, pq)
+    return TreeSearch.tree_search_output(space)
 end

--- a/test/unit/Algorithm/explore.jl
+++ b/test/unit/Algorithm/explore.jl
@@ -32,7 +32,7 @@ struct CustomBestFirstSearch <: Coluna.TreeSearch.AbstractBestFirstSearch end
 
 Coluna.TreeSearch.get_priority(::CustomBestFirstSearch, node::NodeAe1) = -node.id
 
-function Coluna.TreeSearch.children(space::CustomSearchSpaceAe1, current, _, _)
+function Coluna.TreeSearch.children(space::CustomSearchSpaceAe1, current, _)
     children = NodeAe1[]
     push!(space.visit_order, current.id)
     if current.depth != space.max_depth &&
@@ -47,7 +47,7 @@ function Coluna.TreeSearch.children(space::CustomSearchSpaceAe1, current, _, _)
     return children
 end
 
-Coluna.TreeSearch.tree_search_output(space::CustomSearchSpaceAe1, _) = space.visit_order
+Coluna.TreeSearch.tree_search_output(space::CustomSearchSpaceAe1) = space.visit_order
 
 function test_dfs()
     search_space = CustomSearchSpaceAe1(2, 3, 11)

--- a/test/unit/TreeSearch/treesearch.jl
+++ b/test/unit/TreeSearch/treesearch.jl
@@ -76,8 +76,11 @@ function Coluna.TreeSearch.new_root(space::TestBaBSearchSpace, input)
     return TestBaBNode(inner, 1) ## root id is set to 1 by default
 end
 
-Coluna.TreeSearch.stop(space::TestBaBSearchSpace, untreated_nodes) = Coluna.TreeSearch.stop(space.inner, untreated_nodes)
-Coluna.TreeSearch.tree_search_output(space::TestBaBSearchSpace, untreated_nodes) = Coluna.TreeSearch.tree_search_output(space.inner, map(n -> n.inner, untreated_nodes))
+function Coluna.TreeSearch.stop(space::TestBaBSearchSpace, untreated_nodes) 
+    inner_untreated_nodes = map(node->node.inner, untreated_nodes)
+    return Coluna.TreeSearch.stop(space.inner, inner_untreated_nodes)
+end
+Coluna.TreeSearch.tree_search_output(space::TestBaBSearchSpace) = Coluna.TreeSearch.tree_search_output(space.inner)
 
 # methods called by native method children (in branch_and_bound.jl)
 Coluna.Algorithm.get_previous(space::TestBaBSearchSpace) = Coluna.Algorithm.get_previous(space.inner)
@@ -150,7 +153,7 @@ function Coluna.Algorithm.new_children(space::TestBaBSearchSpace, branches::Colu
     return children 
 end
 
-Coluna.Algorithm.node_change!(previous::Coluna.Algorithm.Node, current::TestBaBNode, space::TestBaBSearchSpace, untreated_nodes) = Coluna.Algorithm.node_change!(previous, current.inner, space.inner, map(n -> n.inner, untreated_nodes))
+Coluna.Algorithm.node_change!(previous::Coluna.Algorithm.Node, current::TestBaBNode, space::TestBaBSearchSpace) = Coluna.Algorithm.node_change!(previous, current.inner, space.inner)
 
 # end of the interface's redefinition 
 


### PR DESCRIPTION
• Correction for output of the global dual bound: for that we moved its calculation from `TreeSearch.children` function to `TreeSearch.stop` function
• At the same time, we simplified the `TreeSearch` interface.
Closes #1077.