### PR TITLE
Fix label in mermaid diagram

### DIFF
--- a/docs/src/api/colgen.md
+++ b/docs/src/api/colgen.md
@@ -279,7 +279,7 @@ flowchart TB;
     id10(Iteration output)
     id1 --> id2
     id2 --yes--> id3
-    id2 --no--> id4
+    id2 --no --> id4
     id3 --> id4
     id4 --> id5
     id5 --subproblem--> id6


### PR DESCRIPTION
Mermaid interprets `o-->` as an arrow starting with a dot, see https://mermaid.js.org/syntax/flowchart.html#multi-directional-arrows. Weirdly enough, it actually does not actually show this dot but it consumes the `o` and we are left with only `n` in the label. Adding this space makes sure that the label is `no`.